### PR TITLE
sfd-1015: update status endpoint to return success/failure/pending

### DIFF
--- a/src/api/v1/schemas/uploader-common.js
+++ b/src/api/v1/schemas/uploader-common.js
@@ -110,6 +110,7 @@ export const baseMetadataSchema = Joi.object({
 }).strict()
 
 // Shared field schemas for uploader response payloads (callback and status endpoints)
+// These use raw CDP states and are shared with the callback contract.
 export const uploaderResponseFields = {
   uploadStatus: Joi.string()
     .valid('initiated', 'pending', 'ready')
@@ -139,6 +140,20 @@ export const uploaderResponseFields = {
       ],
       otherwise: Joi.optional()
     })
+}
+
+// Consumer-facing status fields for the status endpoint response.
+// Raw CDP states are mapped to these values before returning to callers.
+export const mappedResponseFields = {
+  uploadStatus: Joi.string()
+    .valid('pending', 'success', 'failure')
+    .required()
+    .description('Consumer-facing status of the upload session')
+    .messages({
+      'any.only': '"uploadStatus" must be one of [pending, success, failure]',
+      'any.required': '"uploadStatus" is required'
+    })
+    .example('success')
 }
 
 // Re-export canonical file upload schema to avoid duplication and drift.

--- a/src/api/v1/uploader/status/index.js
+++ b/src/api/v1/uploader/status/index.js
@@ -112,7 +112,7 @@ export const uploaderStatusRoute = {
 }
 
 const mapCdpStatus = (cdpResponse) => {
-  const { uploadStatus, numberOfRejectedFiles, ...rest } = cdpResponse
+  const { uploadStatus, numberOfRejectedFiles, form, metadata } = cdpResponse
 
   let mappedStatus
   if (uploadStatus === 'ready') {
@@ -121,5 +121,5 @@ const mapCdpStatus = (cdpResponse) => {
     mappedStatus = 'pending'
   }
 
-  return { ...rest, uploadStatus: mappedStatus }
+  return { uploadStatus: mappedStatus, form, metadata }
 }

--- a/src/api/v1/uploader/status/index.js
+++ b/src/api/v1/uploader/status/index.js
@@ -106,7 +106,20 @@ export const uploaderStatusRoute = {
 
       logger.info(buildStatusResponseLog(uploadId, cdpResponse, duration), 'CDP Uploader status response received')
 
-      return h.response({ data: cdpResponse }).code(httpConstants.HTTP_STATUS_OK)
+      return h.response({ data: mapCdpStatus(cdpResponse) }).code(httpConstants.HTTP_STATUS_OK)
     }
   }
+}
+
+const mapCdpStatus = (cdpResponse) => {
+  const { uploadStatus, numberOfRejectedFiles, ...rest } = cdpResponse
+
+  let mappedStatus
+  if (uploadStatus === 'ready') {
+    mappedStatus = numberOfRejectedFiles === 0 ? 'success' : 'failure'
+  } else {
+    mappedStatus = 'pending'
+  }
+
+  return { ...rest, uploadStatus: mappedStatus }
 }

--- a/src/api/v1/uploader/status/schema.js
+++ b/src/api/v1/uploader/status/schema.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { constants as httpConstants } from 'node:http2'
 
 import { generateResponseSchemas, badGatewayResponseSchema, gatewayTimeoutResponseSchema } from '../../schemas/responses.js'
-import { fileUploadSchema, uploaderResponseFields } from '../../schemas/uploader-common.js'
+import { fileUploadSchema, uploaderResponseFields, mappedResponseFields } from '../../schemas/uploader-common.js'
 import { schemaConsts } from '../../../../constants/schemas.js'
 
 export const uploaderStatusParamsSchema = Joi.object({
@@ -68,7 +68,14 @@ export const cdpUploaderStatusResponseSchema = Joi.object({
 }).unknown(true).label('CdpUploaderStatusResponse')
 
 const uploaderStatusSuccessSchema = Joi.object({
-  data: cdpUploaderStatusResponseSchema.required()
+  data: Joi.object({
+    uploadStatus: mappedResponseFields.uploadStatus,
+    metadata: Joi.object()
+      .required()
+      .description('Metadata associated with the upload session')
+      .label('MappedStatusMetadata'),
+    form: cdpStatusFormSchema
+  }).unknown(true).required().label('MappedUploaderStatusData')
 }).label('UploaderStatusSuccessResponse')
 
 const statusNotFoundResponseSchema = Joi.object({

--- a/src/api/v1/uploader/status/schema.js
+++ b/src/api/v1/uploader/status/schema.js
@@ -75,7 +75,7 @@ const uploaderStatusSuccessSchema = Joi.object({
       .description('Metadata associated with the upload session')
       .label('MappedStatusMetadata'),
     form: cdpStatusFormSchema
-  }).unknown(true).required().label('MappedUploaderStatusData')
+  }).required().label('MappedUploaderStatusData')
 }).label('UploaderStatusSuccessResponse')
 
 const statusNotFoundResponseSchema = Joi.object({

--- a/src/api/v1/uploader/status/schema.js
+++ b/src/api/v1/uploader/status/schema.js
@@ -65,7 +65,7 @@ export const cdpUploaderStatusResponseSchema = Joi.object({
   form: cdpStatusFormSchema,
 
   numberOfRejectedFiles: uploaderResponseFields.numberOfRejectedFiles
-}).unknown(true).label('CdpUploaderStatusResponse')
+}).label('CdpUploaderStatusResponse')
 
 const uploaderStatusSuccessSchema = Joi.object({
   data: Joi.object({

--- a/test/integration/narrow/api/uploader/status.test.js
+++ b/test/integration/narrow/api/uploader/status.test.js
@@ -94,7 +94,7 @@ afterEach(() => {
 // ─── Successful responses ────────────────────────────────────────────────────
 
 describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () => {
-  test('returns 200 with data envelope for a ready upload', async () => {
+  test('returns 200 with data envelope for a ready upload with no rejections (success)', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -108,8 +108,8 @@ describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () =
 
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
     expect(response.result.data).toBeDefined()
-    expect(response.result.data.uploadStatus).toBe('ready')
-    expect(response.result.data.numberOfRejectedFiles).toBe(0)
+    expect(response.result.data.uploadStatus).toBe('success')
+    expect(response.result.data.numberOfRejectedFiles).toBeUndefined()
     expect(response.result.data.form['file-field'].fileId).toBe(completeFile.fileId)
   })
 
@@ -165,10 +165,10 @@ describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () =
     })
 
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(response.result.data.uploadStatus).toBe('initiated')
+    expect(response.result.data.uploadStatus).toBe('pending')
   })
 
-  test('returns 200 with rejected file details including GDS error message', async () => {
+  test('returns 200 with failure status and no numberOfRejectedFiles when files are rejected', async () => {
     const responseWithRejection = {
       ...mockReadyResponse,
       form: { 'file-field': rejectedFile },
@@ -186,7 +186,8 @@ describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () =
     })
 
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(response.result.data.numberOfRejectedFiles).toBe(1)
+    expect(response.result.data.uploadStatus).toBe('failure')
+    expect(response.result.data.numberOfRejectedFiles).toBeUndefined()
     const file = response.result.data.form['file-field']
     expect(file.fileStatus).toBe('rejected')
     expect(file.hasError).toBe(true)
@@ -214,8 +215,9 @@ describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () =
 // ─── Polling scenario ────────────────────────────────────────────────────────
 
 describe('GET /api/v1/uploader/status/{uploadId} — polling scenario', () => {
-  test('multiple sequential checks for the same uploadId each return 200', async () => {
-    // Simulate a polling flow: initiated → pending → ready
+  test('multiple sequential checks for the same uploadId each return 200 with mapped statuses', async () => {
+    // Simulate a polling flow: initiated → pending → ready (0 rejections)
+    // Expected mapped output:    pending  → pending → success
     global.fetch = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -240,11 +242,11 @@ describe('GET /api/v1/uploader/status/{uploadId} — polling scenario', () => {
     ])
 
     expect(responses[0].statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(responses[0].result.data.uploadStatus).toBe('initiated')
+    expect(responses[0].result.data.uploadStatus).toBe('pending')
     expect(responses[1].statusCode).toBe(httpConstants.HTTP_STATUS_OK)
     expect(responses[1].result.data.uploadStatus).toBe('pending')
     expect(responses[2].statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(responses[2].result.data.uploadStatus).toBe('ready')
+    expect(responses[2].result.data.uploadStatus).toBe('success')
     expect(global.fetch).toHaveBeenCalledTimes(3)
   })
 })

--- a/test/unit/api/v1/uploader/schemas/common.test.js
+++ b/test/unit/api/v1/uploader/schemas/common.test.js
@@ -6,7 +6,8 @@ import {
   submissionFields,
   baseMetadataSchema,
   fileUploadSchema,
-  uploaderResponseFields
+  uploaderResponseFields,
+  mappedResponseFields
 } from '../../../../../../src/api/v1/schemas/uploader-common.js'
 
 describe('Shared Schema Components', () => {
@@ -589,6 +590,53 @@ describe('uploaderResponseFields', () => {
 
     test('string value fails when uploadStatus is ready', () => {
       const { error } = wrapperSchema.validate({ uploadStatus: 'ready', numberOfRejectedFiles: 'zero' })
+      expect(error).toBeDefined()
+    })
+  })
+})
+
+describe('mappedResponseFields', () => {
+  describe('uploadStatus field', () => {
+    test('valid status "pending" passes', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate('pending')
+      expect(error).toBeUndefined()
+    })
+
+    test('valid status "success" passes', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate('success')
+      expect(error).toBeUndefined()
+    })
+
+    test('valid status "failure" passes', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate('failure')
+      expect(error).toBeUndefined()
+    })
+
+    test('raw CDP status "ready" fails', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate('ready')
+      expect(error).toBeDefined()
+      expect(error.message).toContain('"uploadStatus" must be one of [pending, success, failure]')
+    })
+
+    test('raw CDP status "initiated" fails', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate('initiated')
+      expect(error).toBeDefined()
+      expect(error.message).toContain('"uploadStatus" must be one of [pending, success, failure]')
+    })
+
+    test('arbitrary string fails', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate('processing')
+      expect(error).toBeDefined()
+    })
+
+    test('missing value fails with any.required error', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate(undefined)
+      expect(error).toBeDefined()
+      expect(error.message).toContain('"uploadStatus" is required')
+    })
+
+    test('null value fails', () => {
+      const { error } = mappedResponseFields.uploadStatus.validate(null)
       expect(error).toBeDefined()
     })
   })

--- a/test/unit/api/v1/uploader/status/handler.test.js
+++ b/test/unit/api/v1/uploader/status/handler.test.js
@@ -59,6 +59,13 @@ const validReadyResponse = {
   numberOfRejectedFiles: 0
 }
 
+const validReadyResponseWithRejections = {
+  uploadStatus: 'ready',
+  metadata: { sbi: 105000000, crn: 1050000000 },
+  form: { 'file-field': completeFile },
+  numberOfRejectedFiles: 2
+}
+
 const validPendingResponse = {
   uploadStatus: 'pending',
   metadata: { sbi: 105000000, crn: 1050000000 },
@@ -129,8 +136,40 @@ describe('uploaderStatusRoute handler', () => {
       const { h, mockResponse, mockCode } = buildMockH()
       await handler(buildMockRequest(), h)
 
-      expect(mockResponse).toHaveBeenCalledWith({ data: validReadyResponse })
+      expect(mockResponse).toHaveBeenCalledWith({
+        data: expect.objectContaining({ uploadStatus: 'success' })
+      })
       expect(mockCode).toHaveBeenCalledWith(httpConstants.HTTP_STATUS_OK)
+    })
+
+    test('ready status with zero rejections maps to success and omits numberOfRejectedFiles', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => validReadyResponse
+      })
+
+      const { h, mockResponse } = buildMockH()
+      await handler(buildMockRequest(), h)
+
+      const [{ data }] = mockResponse.mock.calls[0]
+      expect(data.uploadStatus).toBe('success')
+      expect(data.numberOfRejectedFiles).toBeUndefined()
+    })
+
+    test('ready status with rejections maps to failure and omits numberOfRejectedFiles', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => validReadyResponseWithRejections
+      })
+
+      const { h, mockResponse } = buildMockH()
+      await handler(buildMockRequest(), h)
+
+      const [{ data }] = mockResponse.mock.calls[0]
+      expect(data.uploadStatus).toBe('failure')
+      expect(data.numberOfRejectedFiles).toBeUndefined()
     })
 
     test('returns 200 with data envelope for pending status', async () => {
@@ -143,7 +182,9 @@ describe('uploaderStatusRoute handler', () => {
       const { h, mockResponse, mockCode } = buildMockH()
       await handler(buildMockRequest(), h)
 
-      expect(mockResponse).toHaveBeenCalledWith({ data: validPendingResponse })
+      expect(mockResponse).toHaveBeenCalledWith({
+        data: expect.objectContaining({ uploadStatus: 'pending' })
+      })
       expect(mockCode).toHaveBeenCalledWith(httpConstants.HTTP_STATUS_OK)
     })
 
@@ -157,7 +198,9 @@ describe('uploaderStatusRoute handler', () => {
       const { h, mockResponse, mockCode } = buildMockH()
       await handler(buildMockRequest(), h)
 
-      expect(mockResponse).toHaveBeenCalledWith({ data: validInitiatedResponse })
+      expect(mockResponse).toHaveBeenCalledWith({
+        data: expect.objectContaining({ uploadStatus: 'pending' })
+      })
       expect(mockCode).toHaveBeenCalledWith(httpConstants.HTTP_STATUS_OK)
     })
 

--- a/test/unit/api/v1/uploader/status/schema.test.js
+++ b/test/unit/api/v1/uploader/status/schema.test.js
@@ -52,6 +52,7 @@ const validMetadata = {
   uosr: '105000000_1733826312'
 }
 
+// TODO: format needs to be updated to match the new response schema
 const validReadyResponse = {
   uploadStatus: 'ready',
   metadata: validMetadata,
@@ -178,13 +179,13 @@ describe('cdpUploaderStatusResponseSchema', () => {
       expect(error).toBeUndefined()
     })
 
-    test('allows unknown top-level fields (non-strict mode)', () => {
+    test('does not allow unknown top-level fields (strict mode)', () => {
       const payload = {
         ...validReadyResponse,
         extraField: 'unexpected but allowed'
       }
       const { error } = cdpUploaderStatusResponseSchema.validate(payload)
-      expect(error).toBeUndefined()
+      expect(error).toBeDefined()
     })
 
     test('numberOfRejectedFiles can be greater than zero', () => {

--- a/test/unit/api/v1/uploader/status/schema.test.js
+++ b/test/unit/api/v1/uploader/status/schema.test.js
@@ -434,4 +434,17 @@ describe('uploaderStatusResponseSchema', () => {
     const { error } = successSchema.validate(validMappedSuccessResponse)
     expect(error).toBeDefined()
   })
+
+  test('200 schema rejects unknown data-level fields', () => {
+    const successSchema = uploaderStatusResponseSchema[httpConstants.HTTP_STATUS_OK]
+
+    const { error } = successSchema.validate({
+      data: {
+        ...validReadyResponse,
+        unknownField: 'unknown field'
+      }
+    })
+
+    expect(error).toBeDefined()
+  })
 })

--- a/test/unit/api/v1/uploader/status/schema.test.js
+++ b/test/unit/api/v1/uploader/status/schema.test.js
@@ -59,6 +59,13 @@ const validReadyResponse = {
   numberOfRejectedFiles: 0
 }
 
+// Mapped response — as returned by the API after status mapping
+const validMappedSuccessResponse = {
+  uploadStatus: 'success',
+  metadata: validMetadata,
+  form: { 'file-field': completeFile }
+}
+
 // ─── uploaderStatusParamsSchema ─────────────────────────────────────────────
 
 describe('uploaderStatusParamsSchema', () => {
@@ -411,13 +418,19 @@ describe('uploaderStatusResponseSchema', () => {
 
   test('200 schema wraps CDP response in data envelope', () => {
     const successSchema = uploaderStatusResponseSchema[httpConstants.HTTP_STATUS_OK]
-    const { error } = successSchema.validate({ data: validReadyResponse })
+    const { error } = successSchema.validate({ data: validMappedSuccessResponse })
     expect(error).toBeUndefined()
+  })
+
+  test('200 schema rejects raw CDP ready status', () => {
+    const successSchema = uploaderStatusResponseSchema[httpConstants.HTTP_STATUS_OK]
+    const { error } = successSchema.validate({ data: validReadyResponse })
+    expect(error).toBeDefined()
   })
 
   test('200 schema rejects missing data envelope', () => {
     const successSchema = uploaderStatusResponseSchema[httpConstants.HTTP_STATUS_OK]
-    const { error } = successSchema.validate(validReadyResponse)
+    const { error } = successSchema.validate(validMappedSuccessResponse)
     expect(error).toBeDefined()
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-1015

## Changes
- update the status endpoint so it returns a more consumer friendly response
- new function to map the cdp uploader status response to include either `success`, `failure` or `pending`
- update schema components so that new values are valid