### PR TITLE
SFD2-1015 Update OpenAPI spec to include dropdown examples for different uploadStatus values

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,14 +160,14 @@
         "filename": "docs/openapi/v1.json",
         "hashed_secret": "74d15c3b586445356972b6961d8d1b968df54a75",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": "docs/openapi/v1.json",
         "hashed_secret": "a97c9203c59d6537d8bbf3d25b5264848366dca7",
         "is_verified": false,
-        "line_number": 567
+        "line_number": 561
       }
     ],
     "scripts/generate-openapi.js": [
@@ -176,7 +176,7 @@
         "filename": "scripts/generate-openapi.js",
         "hashed_secret": "74d15c3b586445356972b6961d8d1b968df54a75",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 101
       }
     ],
     "src/constants/schemas.js": [
@@ -354,5 +354,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-31T15:51:57Z"
+  "generated_at": "2026-04-09T14:24:29Z"
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -315,27 +315,17 @@
       },
       "uploadStatus": {
         "type": "string",
-        "description": "Status of the upload session",
-        "example": "ready",
+        "description": "Consumer-facing status of the upload session",
+        "example": "success",
         "enum": [
-          "initiated",
           "pending",
-          "ready"
+          "success",
+          "failure"
         ]
       },
-      "CdpStatusMetadata": {
+      "MappedStatusMetadata": {
         "type": "object",
-        "description": "Metadata associated with the upload session",
-        "example": {
-          "sbi": 105000000,
-          "crn": 1050000000,
-          "frn": 1102658375,
-          "submissionId": "1733826312",
-          "uosr": "105000000_1733826312",
-          "type": "CS_Agreement_Evidence",
-          "reference": "user entered reference",
-          "service": "fcp-sfd-frontend"
-        }
+        "description": "Metadata associated with the upload session"
       },
       "CdpStatusForm": {
         "type": "object",
@@ -354,23 +344,17 @@
           }
         }
       },
-      "CdpUploaderStatusResponse": {
+      "MappedUploaderStatusData": {
         "type": "object",
         "properties": {
           "uploadStatus": {
             "$ref": "#/components/schemas/uploadStatus"
           },
           "metadata": {
-            "$ref": "#/components/schemas/CdpStatusMetadata"
+            "$ref": "#/components/schemas/MappedStatusMetadata"
           },
           "form": {
             "$ref": "#/components/schemas/CdpStatusForm"
-          },
-          "numberOfRejectedFiles": {
-            "type": "integer",
-            "description": "Number of files rejected during upload",
-            "example": 0,
-            "minimum": 0
           }
         },
         "required": [
@@ -383,7 +367,7 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/CdpUploaderStatusResponse"
+            "$ref": "#/components/schemas/MappedUploaderStatusData"
           }
         },
         "required": [
@@ -440,6 +424,16 @@
             "example": "CDP Uploader request timed out"
           }
         }
+      },
+      "Model1": {
+        "type": "string",
+        "description": "Status of the upload session",
+        "example": "ready",
+        "enum": [
+          "initiated",
+          "pending",
+          "ready"
+        ]
       },
       "service": {
         "type": "string",
@@ -540,7 +534,7 @@
         "description": "Callback payload from CDP Uploader after file upload processing",
         "properties": {
           "uploadStatus": {
-            "$ref": "#/components/schemas/uploadStatus"
+            "$ref": "#/components/schemas/Model1"
           },
           "metadata": {
             "$ref": "#/components/schemas/UploadMetadata"
@@ -977,7 +971,7 @@
       "get": {
         "summary": "Proxy CDP Uploader scan status for an upload session",
         "operationId": "getApiV1UploaderStatusUploadid",
-        "description": "Polls CDP Uploader for the current scan status and file details for a given uploadId.",
+        "description": "Polls CDP Uploader for the current scan status and file details for a given uploadId. Note that this endpoint has multiple response examples based on uploadStatus. If not rendering on the /documentation endpoint, please use the official Swagger Editor (online or the VS Code extension).",
         "parameters": [
           {
             "name": "uploadId",
@@ -1008,6 +1002,95 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UploaderStatusSuccessResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "All files uploaded successfully",
+                    "value": {
+                      "data": {
+                        "uploadStatus": "success",
+                        "metadata": {
+                          "sbi": 105000000,
+                          "crn": 1050000000,
+                          "frn": 1102658375,
+                          "submissionId": "1733826312",
+                          "uosr": "105000000_1733826312",
+                          "type": "CS_Agreement_Evidence",
+                          "reference": "user entered reference",
+                          "service": "fcp-sfd-frontend"
+                        },
+                        "form": {
+                          "file-upload-1": {
+                            "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
+                            "filename": "document.pdf",
+                            "contentType": "application/pdf",
+                            "detectedContentType": "application/pdf",
+                            "fileStatus": "complete",
+                            "contentLength": 11264,
+                            "checksumSha256": "bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c=",
+                            "s3Key": "scanned/folder/9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
+                            "s3Bucket": "fcp-sfd-object-processor-bucket"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "failure": {
+                    "summary": "One or more files rejected",
+                    "value": {
+                      "data": {
+                        "uploadStatus": "failure",
+                        "metadata": {
+                          "sbi": 105000000,
+                          "crn": 1050000000,
+                          "frn": 1102658375,
+                          "submissionId": "1733826312",
+                          "uosr": "105000000_1733826312",
+                          "type": "CS_Agreement_Evidence",
+                          "reference": "user entered reference",
+                          "service": "fcp-sfd-frontend"
+                        },
+                        "form": {
+                          "file-upload-1": {
+                            "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
+                            "filename": "document.pdf",
+                            "contentType": "application/pdf",
+                            "detectedContentType": "application/pdf",
+                            "fileStatus": "rejected",
+                            "hasError": true,
+                            "errorMessage": "File rejected: virus detected"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pending": {
+                    "summary": "Upload still processing",
+                    "value": {
+                      "data": {
+                        "uploadStatus": "pending",
+                        "metadata": {
+                          "sbi": 105000000,
+                          "crn": 1050000000,
+                          "frn": 1102658375,
+                          "submissionId": "1733826312",
+                          "uosr": "105000000_1733826312",
+                          "type": "CS_Agreement_Evidence",
+                          "reference": "user entered reference",
+                          "service": "fcp-sfd-frontend"
+                        },
+                        "form": {
+                          "file-upload-1": {
+                            "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
+                            "filename": "document.pdf",
+                            "contentType": "application/pdf",
+                            "detectedContentType": "application/pdf",
+                            "fileStatus": "pending"
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -425,7 +425,7 @@
           }
         }
       },
-      "Model1": {
+      "UploadSessionStatus": {
         "type": "string",
         "description": "Status of the upload session",
         "example": "ready",
@@ -534,7 +534,7 @@
         "description": "Callback payload from CDP Uploader after file upload processing",
         "properties": {
           "uploadStatus": {
-            "$ref": "#/components/schemas/Model1"
+            "$ref": "#/components/schemas/UploadSessionStatus"
           },
           "metadata": {
             "$ref": "#/components/schemas/UploadMetadata"
@@ -1055,8 +1055,8 @@
                             "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
                             "filename": "document.pdf",
                             "contentType": "application/pdf",
-                            "detectedContentType": "application/pdf",
                             "fileStatus": "rejected",
+                            "contentLength": 11264,
                             "hasError": true,
                             "errorMessage": "File rejected: virus detected"
                           }

--- a/scripts/generate-openapi.js
+++ b/scripts/generate-openapi.js
@@ -174,8 +174,7 @@ const generateOpenapi = async (outputPath = './docs/openapi/v1.json') => {
       const baseFileFields = {
         fileId: schemaConsts.FILE_ID_EXAMPLE,
         filename: schemaConsts.FILENAME_EXAMPLE,
-        contentType: schemaConsts.CONTENT_TYPE_EXAMPLE,
-        detectedContentType: schemaConsts.DETECTED_CONTENT_TYPE_EXAMPLE
+        contentType: schemaConsts.CONTENT_TYPE_EXAMPLE
       }
 
       statusMediaType.examples = {
@@ -188,6 +187,7 @@ const generateOpenapi = async (outputPath = './docs/openapi/v1.json') => {
               form: {
                 'file-upload-1': {
                   ...baseFileFields,
+                  detectedContentType: schemaConsts.DETECTED_CONTENT_TYPE_EXAMPLE,
                   fileStatus: 'complete',
                   contentLength: schemaConsts.CONTENT_LENGTH_EXAMPLE,
                   checksumSha256: schemaConsts.CHECKSUM_SHA256_EXAMPLE,
@@ -208,6 +208,7 @@ const generateOpenapi = async (outputPath = './docs/openapi/v1.json') => {
                 'file-upload-1': {
                   ...baseFileFields,
                   fileStatus: 'rejected',
+                  contentLength: schemaConsts.CONTENT_LENGTH_EXAMPLE,
                   hasError: true,
                   errorMessage: schemaConsts.ERROR_MESSAGE_EXAMPLE
                 }
@@ -224,6 +225,7 @@ const generateOpenapi = async (outputPath = './docs/openapi/v1.json') => {
               form: {
                 'file-upload-1': {
                   ...baseFileFields,
+                  detectedContentType: schemaConsts.DETECTED_CONTENT_TYPE_EXAMPLE,
                   fileStatus: 'pending'
                 }
               }

--- a/scripts/generate-openapi.js
+++ b/scripts/generate-openapi.js
@@ -1,4 +1,5 @@
 import { writeFile } from 'node:fs/promises'
+import { schemaConsts } from '../src/constants/schemas.js'
 
 /**
  * Generates OpenAPI specification by fetching from the running server
@@ -151,6 +152,87 @@ const generateOpenapi = async (outputPath = './docs/openapi/v1.json') => {
       }
     }
 
+    // Post-process: Inject named examples for uploader status 200 response.
+    // hapi-swagger only renders a single schema-level `example`; OAS 3.0
+    // supports named `examples` at the media-type level which Swagger UI
+    // presents as a dropdown.
+    const statusMediaType =
+      spec.paths?.['/api/v1/uploader/status/{uploadId}']?.get?.responses?.['200']?.content?.['application/json']
+
+    if (statusMediaType) {
+      const metadata = {
+        sbi: schemaConsts.SBI_EXAMPLE,
+        crn: schemaConsts.CRN_EXAMPLE,
+        frn: schemaConsts.FRN_EXAMPLE,
+        submissionId: schemaConsts.SUBMISSION_ID_EXAMPLE,
+        uosr: schemaConsts.UOSR_EXAMPLE,
+        type: schemaConsts.TYPE_EXAMPLE,
+        reference: schemaConsts.REFERENCE_EXAMPLE,
+        service: schemaConsts.SERVICE_EXAMPLE
+      }
+
+      const baseFileFields = {
+        fileId: schemaConsts.FILE_ID_EXAMPLE,
+        filename: schemaConsts.FILENAME_EXAMPLE,
+        contentType: schemaConsts.CONTENT_TYPE_EXAMPLE,
+        detectedContentType: schemaConsts.DETECTED_CONTENT_TYPE_EXAMPLE
+      }
+
+      statusMediaType.examples = {
+        success: {
+          summary: 'All files uploaded successfully',
+          value: {
+            data: {
+              uploadStatus: 'success',
+              metadata,
+              form: {
+                'file-upload-1': {
+                  ...baseFileFields,
+                  fileStatus: 'complete',
+                  contentLength: schemaConsts.CONTENT_LENGTH_EXAMPLE,
+                  checksumSha256: schemaConsts.CHECKSUM_SHA256_EXAMPLE,
+                  s3Key: schemaConsts.S3_KEY_EXAMPLE,
+                  s3Bucket: schemaConsts.S3_BUCKET_EXAMPLE
+                }
+              }
+            }
+          }
+        },
+        failure: {
+          summary: 'One or more files rejected',
+          value: {
+            data: {
+              uploadStatus: 'failure',
+              metadata,
+              form: {
+                'file-upload-1': {
+                  ...baseFileFields,
+                  fileStatus: 'rejected',
+                  hasError: true,
+                  errorMessage: schemaConsts.ERROR_MESSAGE_EXAMPLE
+                }
+              }
+            }
+          }
+        },
+        pending: {
+          summary: 'Upload still processing',
+          value: {
+            data: {
+              uploadStatus: 'pending',
+              metadata,
+              form: {
+                'file-upload-1': {
+                  ...baseFileFields,
+                  fileStatus: 'pending'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     // Write to file
     await writeFile(outputPath, JSON.stringify(spec, null, 2))
 
@@ -159,6 +241,7 @@ const generateOpenapi = async (outputPath = './docs/openapi/v1.json') => {
     console.log(`   📄 Output: ${outputPath}`)
     console.log('   🔒 Security: bearerAuth scheme configured')
     console.log('   📦 Components: FileUpload schema injected')
+    console.log('   📝 Examples: uploader status response examples injected')
     console.log(`   📊 Total schemas: ${Object.keys(spec.components?.schemas || {}).length}`)
     console.log(`   🛣️  Paths: ${Object.keys(spec.paths || {}).length} endpoints`)
   } catch (error) {

--- a/src/api/v1/schemas/uploader-common.js
+++ b/src/api/v1/schemas/uploader-common.js
@@ -120,7 +120,8 @@ export const uploaderResponseFields = {
       'any.only': '"uploadStatus" must be one of [initiated, pending, ready]',
       'any.required': '"uploadStatus" is required'
     })
-    .example('ready'),
+    .example('ready')
+    .label('UploadSessionStatus'),
 
   numberOfRejectedFiles: Joi.number()
     .integer()

--- a/src/api/v1/uploader/status/index.js
+++ b/src/api/v1/uploader/status/index.js
@@ -25,7 +25,7 @@ export const uploaderStatusRoute = {
   path: `${baseUrl}/uploader/status/{uploadId}`,
   options: {
     description: 'Proxy CDP Uploader scan status for an upload session',
-    notes: 'Polls CDP Uploader for the current scan status and file details for a given uploadId.',
+    notes: 'Polls CDP Uploader for the current scan status and file details for a given uploadId. Note that this endpoint has multiple response examples based on uploadStatus. If not rendering on the /documentation endpoint, please use the official Swagger Editor (online or the VS Code extension).',
     tags: ['api', 'uploader'],
     validate: {
       params: uploaderStatusParamsSchema,


### PR DESCRIPTION
# SFD2-1015 Update OpenAPI spec to better reflect different responses for `uploadStatus`

Ticket - [SFD2-1015](https://eaflood.atlassian.net/browse/SFD2-1015)

## Description

The `hapi-swagger` plugin has limitations when showing multiple examples for the different responses of `uploadStatus` e.g. `pending`, `failure`, `success`. It was discovered by @simonnineteen90 that using the official Swagger Editor or the VS Code extension will in fact render multiple examples, but the service's `/documentation` endpoint will not render these. 

The multiple examples are rendered as a drop down. Example screenshot below:
<img width="278" height="117" alt="image" src="https://github.com/user-attachments/assets/86344cc3-770d-41a9-a613-1032df8b4596" />

## Changes
- The `generateOpenApi` script has been updated to include examples for an `uploadStatus` of `success`, `failure`, or `pending`. It utilises the existing `schemaConsts` to help ensure the script is maintainable/doesn't require manual editing any time there's changes to the contract.
- The `notes` on the `api/v1/uploader/status/{uploadId}` endpoint has been updated to include a note on use of the official Swagger Editor where `hapi-swagger` poses limitations.
- OpenAPI spec has naturally been regenerated as a result of the above changes.

[SFD2-1015]: https://eaflood.atlassian.net/browse/SFD2-1015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ