### PR TITLE
fix-status-response-schema-for-failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,9 +2594,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
+      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -2625,6 +2625,7 @@
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.12.tgz",
       "integrity": "sha512-GCUP12dkb3QMjpFl+wEFO73nqKRmsnD5um/QDOn6lj2GjGBrDXPcT194mNARO+PPNXZOR4KmvIpHt/lceUncfg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/accept": "^6.0.3",
         "@hapi/ammo": "^6.0.1",
@@ -3051,6 +3052,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6636,6 +6638,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -7257,6 +7260,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7806,6 +7810,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8426,6 +8431,7 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -8800,6 +8806,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8890,82 +8897,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-import-x": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
-      "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "^8.35.0",
-        "comment-parser": "^1.4.1",
-        "debug": "^4.4.1",
-        "eslint-import-context": "^0.1.9",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.3 || ^10.0.1",
-        "semver": "^7.7.2",
-        "stable-hash-x": "^0.2.0",
-        "unrs-resolver": "^1.9.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-import-x"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/utils": "^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "eslint-import-resolver-node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/utils": {
-          "optional": true
-        },
-        "eslint-import-resolver-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -10796,6 +10727,7 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
       "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -11310,6 +11242,7 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
       "integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.5",
         "bson": "^6.7.0",
@@ -12385,6 +12318,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12924,6 +12858,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14181,11 +14116,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -14284,6 +14220,7 @@
       "integrity": "sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.1.3",
         "@vitest/mocker": "3.1.3",

--- a/src/api/v1/schemas/file-upload-schema.js
+++ b/src/api/v1/schemas/file-upload-schema.js
@@ -15,7 +15,7 @@ const EMPTY_FIELD_MESSAGE = '"{#label}" cannot be empty'
  *
  * fileStatus: 'complete' | 'rejected' | 'pending'
  * - complete: must have s3Key, s3Bucket, checksumSha256, contentLength > 0; must NOT have hasError/errorMessage
- * - rejected: must have hasError=true and non-empty errorMessage; must NOT have s3Key/s3Bucket/checksum
+ * - rejected: must have hasError=true and non-empty errorMessage; must NOT have s3Key/s3Bucket/checksum/detectedContentType
  * - pending: minimal constraints (fileId, filename, contentType, detectedContentType allowed)
  *
  * Exported as `fileUploadSchema` for reuse by callback, status, and initiate endpoints.
@@ -108,10 +108,11 @@ export const fileUploadSchema = Joi.object({
       errorMessage: Joi.forbidden()
     })
   })
-  .when(Joi.object({ fileStatus: 'rejected' }).unknown(), {
+  .when(Joi.object({ fileStatus: Joi.valid('rejected').required() }).unknown(), {
     then: Joi.object({
       hasError: Joi.valid(true).required(),
       errorMessage: Joi.string().min(1).required(),
+      detectedContentType: Joi.forbidden(),
       s3Key: Joi.forbidden(),
       s3Bucket: Joi.forbidden(),
       checksumSha256: Joi.forbidden()

--- a/src/api/v1/schemas/file-upload-schema.js
+++ b/src/api/v1/schemas/file-upload-schema.js
@@ -98,7 +98,7 @@ export const fileUploadSchema = Joi.object({
     .messages({ 'string.empty': EMPTY_FIELD_MESSAGE })
     .example(schemaConsts.S3_BUCKET_EXAMPLE).label('s3Bucket')
 })
-  .when(Joi.object({ fileStatus: 'complete' }).unknown(), {
+  .when(Joi.object({ fileStatus: Joi.valid('complete').required() }).unknown(), {
     then: Joi.object({
       s3Key: Joi.required(),
       s3Bucket: Joi.required(),

--- a/test/integration/narrow/api/callback.test.js
+++ b/test/integration/narrow/api/callback.test.js
@@ -117,7 +117,6 @@ describe('POST to the /api/v1/callback route', async () => {
         fileId: '550e8400-e29b-41d4-a716-446655440001',
         filename: 'infected.pdf',
         contentType: 'application/pdf',
-        detectedContentType: 'application/pdf',
         fileStatus: 'rejected',
         hasError: true,
         errorMessage: 'File contains virus: Trojan.Generic'
@@ -157,7 +156,6 @@ describe('POST to the /api/v1/callback route', async () => {
         fileId: '550e8400-e29b-41d4-a716-446655440002',
         filename: 'rejected-no-msg.pdf',
         contentType: 'application/pdf',
-        detectedContentType: 'application/pdf',
         fileStatus: 'rejected',
         hasError: true
       }
@@ -239,7 +237,6 @@ describe('POST to the /api/v1/callback route', async () => {
         fileId: '550e8400-e29b-41d4-a716-446655440021',
         filename: 'infected.pdf',
         contentType: 'application/pdf',
-        detectedContentType: 'application/pdf',
         fileStatus: 'rejected',
         hasError: true,
         errorMessage: 'Virus detected'

--- a/test/integration/narrow/api/uploader/status.test.js
+++ b/test/integration/narrow/api/uploader/status.test.js
@@ -34,7 +34,6 @@ const rejectedFile = {
   fileId: 'c2d3e4f5-a6b7-4789-abcd-ef0123456789',
   filename: 'virus.exe',
   contentType: 'application/octet-stream',
-  detectedContentType: 'application/octet-stream',
   fileStatus: 'rejected',
   hasError: true,
   errorMessage: 'File rejected: virus detected'
@@ -192,6 +191,29 @@ describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () =
     expect(file.fileStatus).toBe('rejected')
     expect(file.hasError).toBe(true)
     expect(file.errorMessage).toBeDefined()
+    expect(file.detectedContentType).toBeUndefined()
+  })
+
+  test('returns 200 with pending status for pending response with full metadata and empty form', async () => {
+    const pendingResponseWithFullMetadata = {
+      uploadStatus: 'pending',
+      metadata: validMetadata,
+      form: {}
+    }
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => pendingResponseWithFullMetadata
+    })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: `/api/v1/uploader/status/${validUploadId}`
+    })
+
+    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
+    expect(response.result.data.uploadStatus).toBe('pending')
+    expect(response.result.data.form).toEqual({})
   })
 
   test('forwards the correct URL to CDP Uploader', async () => {

--- a/test/unit/api/v1/callback/contract-validation.test.js
+++ b/test/unit/api/v1/callback/contract-validation.test.js
@@ -13,6 +13,7 @@ describe('callback contract validation (fileStatus variants)', () => {
     delete file.s3Key
     delete file.s3Bucket
     delete file.checksumSha256
+    delete file.detectedContentType
     payload.form = { 'rejected-file': file }
 
     const { error } = callbackPayloadSchema.validate(payload)
@@ -22,6 +23,11 @@ describe('callback contract validation (fileStatus variants)', () => {
   test('REJECTED file without errorMessage fails validation', () => {
     const payload = { ...base }
     const file = { ...payload.form['a-file-upload-field'], fileStatus: 'rejected', hasError: true }
+    // remove fields that are forbidden for rejected files
+    delete file.s3Key
+    delete file.s3Bucket
+    delete file.checksumSha256
+    delete file.detectedContentType
     // remove errorMessage explicitly if present
     delete file.errorMessage
     payload.form = { 'rejected-file': file }
@@ -107,7 +113,6 @@ describe('fileUploadSchema Joi edge cases', () => {
       fileId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
       filename: 'test.pdf',
       contentType: 'application/pdf',
-      detectedContentType: 'application/pdf',
       fileStatus: 'rejected',
       hasError: true,
       errorMessage: ''
@@ -121,7 +126,6 @@ describe('fileUploadSchema Joi edge cases', () => {
       fileId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
       filename: 'test.pdf',
       contentType: 'application/pdf',
-      detectedContentType: 'application/pdf',
       fileStatus: 'rejected',
       hasError: false,
       errorMessage: 'error'

--- a/test/unit/api/v1/uploader/schemas/common.test.js
+++ b/test/unit/api/v1/uploader/schemas/common.test.js
@@ -426,8 +426,9 @@ describe('Shared Schema Components', () => {
     })
 
     test('should require hasError=true and errorMessage for rejected files', () => {
+      const { detectedContentType, ...baseFileUploadWithoutDetected } = baseFileUpload
       const rejectedFile = {
-        ...baseFileUpload,
+        ...baseFileUploadWithoutDetected,
         fileStatus: 'rejected',
         hasError: true,
         errorMessage: 'Virus detected'
@@ -436,7 +437,7 @@ describe('Shared Schema Components', () => {
       expect(validResult.error).toBeUndefined()
 
       const invalidRejectedFile = {
-        ...baseFileUpload,
+        ...baseFileUploadWithoutDetected,
         fileStatus: 'rejected',
         hasError: false,
         errorMessage: 'Virus detected'

--- a/test/unit/api/v1/uploader/status/schema.test.js
+++ b/test/unit/api/v1/uploader/status/schema.test.js
@@ -35,7 +35,6 @@ const rejectedFile = {
   fileId: 'a0b1c2d3-e4f5-4789-abcd-ef0123456789',
   filename: 'document.pdf',
   contentType: 'application/pdf',
-  detectedContentType: 'application/pdf',
   fileStatus: 'rejected',
   hasError: true,
   errorMessage: 'File rejected: virus detected'
@@ -145,6 +144,28 @@ describe('cdpUploaderStatusResponseSchema', () => {
       }
       const { error } = cdpUploaderStatusResponseSchema.validate(payload)
       expect(error).toBeUndefined()
+    })
+
+    test('rejected file without detectedContentType passes (CDP Uploader never includes it)', () => {
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': rejectedFile },
+        numberOfRejectedFiles: 1
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeUndefined()
+    })
+
+    test('rejected file with detectedContentType fails (it is forbidden for rejected files)', () => {
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': { ...rejectedFile, detectedContentType: 'application/pdf' } },
+        numberOfRejectedFiles: 1
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeDefined()
     })
 
     test('form allows mix of file objects and string fields', () => {
@@ -446,5 +467,29 @@ describe('uploaderStatusResponseSchema', () => {
     })
 
     expect(error).toBeDefined()
+  })
+
+  test('200 schema accepts failure response with rejected file (no detectedContentType)', () => {
+    const successSchema = uploaderStatusResponseSchema[httpConstants.HTTP_STATUS_OK]
+    const { error } = successSchema.validate({
+      data: {
+        uploadStatus: 'failure',
+        metadata: validMetadata,
+        form: { 'file-upload-1': rejectedFile }
+      }
+    })
+    expect(error).toBeUndefined()
+  })
+
+  test('200 schema accepts pending response with full metadata and empty form', () => {
+    const successSchema = uploaderStatusResponseSchema[httpConstants.HTTP_STATUS_OK]
+    const { error } = successSchema.validate({
+      data: {
+        uploadStatus: 'pending',
+        metadata: validMetadata,
+        form: {}
+      }
+    })
+    expect(error).toBeUndefined()
   })
 })


### PR DESCRIPTION
Follow up from: https://eaflood.atlassian.net/browse/SFD2-1015
Links to #49 and #50 

## Changes 
The current schema is blocking status responses because it is expected `detectedContentType` to be included but this value is not present when a file is rejected. 

This PR amends the schema to allow failure status responses to be successfully returned and updates the corresponding tests