### PR TITLE
refactor to ecs logging

### DIFF
--- a/src/api/v1/callback/index.js
+++ b/src/api/v1/callback/index.js
@@ -7,6 +7,7 @@ import { config } from '../../../config/index.js'
 import { persistMetadataWithOutbox, persistValidationFailureStatus } from '../../../services/metadata-service.js'
 import { metricsCounter } from '../../common/helpers/metrics.js'
 import { validateCallbackPayload } from './validation/validate-callback-payload.js'
+import { buildCallbackValidationFailureLog, buildCallbackPersistFailureLog } from '../../../utils/build-callback-validation-failure-log.js'
 
 const logger = createLogger()
 const baseUrl = config.get('baseUrl.v1')
@@ -33,13 +34,13 @@ export const uploadCallback = {
       payload: callbackPayloadSchema,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
-        logger.error({ error: { message: err.message } }, 'Validation failed')
+        logger.error(buildCallbackValidationFailureLog(request, err), 'Validation failed')
         await metricsCounter('callback_validation_failures')
 
         try {
           await persistValidationFailureStatus(request.payload, err)
         } catch (persistError) {
-          logger.error(persistError, 'Failed to persist status for callback validation failure')
+          logger.error(buildCallbackPersistFailureLog(request, persistError), 'Failed to persist status for callback validation failure')
         }
 
         return h.response({ message: 'Validation failure persisted' }).code(httpConstants.HTTP_STATUS_CREATED).takeover()

--- a/src/utils/build-callback-validation-failure-log.js
+++ b/src/utils/build-callback-validation-failure-log.js
@@ -1,0 +1,44 @@
+/**
+ * Builds the structured log context for a Joi schema validation failure on the callback endpoint.
+ * Uses approved ECS event.* and error.* fields only.
+ * @param {object} request - Hapi request object
+ * @param {Error} err - Joi validation error
+ */
+export const buildCallbackValidationFailureLog = (request, err) => {
+  return {
+    event: {
+      type: 'callback_validation_failure',
+      action: request.method,
+      category: request.path,
+      outcome: 'failure',
+      reference: request.payload?.metadata?.uosr
+    },
+    error: {
+      code: err.statusCode ?? err.code,
+      message: err.message,
+      stack_trace: err.stack,
+      type: err.constructor.name
+    }
+  }
+}
+/**
+ * Builds the structured log context for a failure to persist validation failure status on the callback endpoint.
+ * Uses approved ECS event.* and error.* fields only.
+ * @param {object} request - Hapi request object
+ * @param {Error} persistError - Error thrown by the persist operation
+ */
+export const buildCallbackPersistFailureLog = (request, persistError) => ({
+  event: {
+    type: 'callback_validation_persist_failure',
+    action: request.method,
+    category: request.path,
+    outcome: 'failure',
+    reference: request.payload?.metadata?.uosr
+  },
+  error: {
+    code: persistError.statusCode ?? persistError.code,
+    message: persistError.message,
+    stack_trace: persistError.stack,
+    type: persistError.constructor.name
+  }
+})

--- a/src/utils/build-callback-validation-failure-log.js
+++ b/src/utils/build-callback-validation-failure-log.js
@@ -14,7 +14,7 @@ export const buildCallbackValidationFailureLog = (request, err) => {
       reference: request.payload?.metadata?.uosr
     },
     error: {
-      code: err.statusCode ?? err.code,
+      code: err.statusCode ?? err.code ?? null,
       message: err.message,
       stack_trace: err.stack,
       type: err.constructor.name
@@ -36,7 +36,7 @@ export const buildCallbackPersistFailureLog = (request, persistError) => ({
     reference: request.payload?.metadata?.uosr
   },
   error: {
-    code: persistError.statusCode ?? persistError.code,
+    code: persistError.statusCode ?? persistError.code ?? null,
     message: persistError.message,
     stack_trace: persistError.stack,
     type: persistError.constructor.name

--- a/test/unit/utils/build-callback-validation-failure-log.test.js
+++ b/test/unit/utils/build-callback-validation-failure-log.test.js
@@ -28,7 +28,7 @@ describe('buildCallbackValidationFailureLog', () => {
         reference: 'sub-123'
       },
       error: {
-        code: undefined,
+        code: null,
         message: 'Validation failed',
         stack_trace: err.stack,
         type: 'Error'
@@ -93,7 +93,7 @@ describe('buildCallbackPersistFailureLog', () => {
         reference: 'sub-123'
       },
       error: {
-        code: undefined,
+        code: null,
         message: 'DB write failed',
         stack_trace: persistError.stack,
         type: 'Error'

--- a/test/unit/utils/build-callback-validation-failure-log.test.js
+++ b/test/unit/utils/build-callback-validation-failure-log.test.js
@@ -1,0 +1,144 @@
+import { describe, test, expect } from 'vitest'
+
+import {
+  buildCallbackValidationFailureLog,
+  buildCallbackPersistFailureLog
+} from '../../../src/utils/build-callback-validation-failure-log.js'
+
+const mockRequest = {
+  path: '/api/v1/callback',
+  method: 'post',
+  payload: {
+    metadata: { uosr: 'sub-123' }
+  }
+}
+
+describe('buildCallbackValidationFailureLog', () => {
+  const err = Object.assign(new Error('Validation failed'), { stack: 'Error: Validation failed\n  at ...' })
+
+  test('returns nested event and error objects with approved ECS fields', () => {
+    const log = buildCallbackValidationFailureLog(mockRequest, err)
+
+    expect(log).toEqual({
+      event: {
+        type: 'callback_validation_failure',
+        action: 'post',
+        category: '/api/v1/callback',
+        outcome: 'failure',
+        reference: 'sub-123'
+      },
+      error: {
+        code: undefined,
+        message: 'Validation failed',
+        stack_trace: err.stack,
+        type: 'Error'
+      }
+    })
+  })
+
+  test('uses uosr from payload as event.reference', () => {
+    const log = buildCallbackValidationFailureLog(mockRequest, err)
+    expect(log.event.reference).toBe('sub-123')
+  })
+
+  test('sets event.reference to undefined when payload is null', () => {
+    const request = { ...mockRequest, payload: null }
+    const log = buildCallbackValidationFailureLog(request, err)
+    expect(log.event.reference).toBeUndefined()
+  })
+
+  test('sets event.reference to undefined when metadata is absent', () => {
+    const request = { ...mockRequest, payload: {} }
+    const log = buildCallbackValidationFailureLog(request, err)
+    expect(log.event.reference).toBeUndefined()
+  })
+
+  test('maps error.code from err.statusCode', () => {
+    const errWithStatus = Object.assign(new Error('Boom'), { statusCode: 422 })
+    const log = buildCallbackValidationFailureLog(mockRequest, errWithStatus)
+    expect(log.error.code).toBe(422)
+  })
+
+  test('falls back to err.code when statusCode is absent', () => {
+    const errWithCode = Object.assign(new Error('DB error'), { code: 'ECONNREFUSED' })
+    const log = buildCallbackValidationFailureLog(mockRequest, errWithCode)
+    expect(log.error.code).toBe('ECONNREFUSED')
+  })
+
+  test('sets error.type to constructor name', () => {
+    class ValidationError extends Error {}
+    const log = buildCallbackValidationFailureLog(mockRequest, new ValidationError('bad'))
+    expect(log.error.type).toBe('ValidationError')
+  })
+
+  test('does not include event.reason (auth is disabled on this route)', () => {
+    const log = buildCallbackValidationFailureLog(mockRequest, err)
+    expect(log.event.reason).toBeUndefined()
+    expect(Object.keys(log.event)).not.toContain('reason')
+  })
+})
+
+describe('buildCallbackPersistFailureLog', () => {
+  const persistError = Object.assign(new Error('DB write failed'), { stack: 'Error: DB write failed\n  at ...' })
+
+  test('returns nested event and error objects with approved ECS fields', () => {
+    const log = buildCallbackPersistFailureLog(mockRequest, persistError)
+
+    expect(log).toEqual({
+      event: {
+        type: 'callback_validation_persist_failure',
+        action: 'post',
+        category: '/api/v1/callback',
+        outcome: 'failure',
+        reference: 'sub-123'
+      },
+      error: {
+        code: undefined,
+        message: 'DB write failed',
+        stack_trace: persistError.stack,
+        type: 'Error'
+      }
+    })
+  })
+
+  test('uses uosr from payload as event.reference', () => {
+    const log = buildCallbackPersistFailureLog(mockRequest, persistError)
+    expect(log.event.reference).toBe('sub-123')
+  })
+
+  test('sets event.reference to undefined when payload is null', () => {
+    const request = { ...mockRequest, payload: null }
+    const log = buildCallbackPersistFailureLog(request, persistError)
+    expect(log.event.reference).toBeUndefined()
+  })
+
+  test('sets event.reference to undefined when metadata is absent', () => {
+    const request = { ...mockRequest, payload: {} }
+    const log = buildCallbackPersistFailureLog(request, persistError)
+    expect(log.event.reference).toBeUndefined()
+  })
+
+  test('maps error.code from persistError.statusCode', () => {
+    const errWithStatus = Object.assign(new Error('Boom'), { statusCode: 500 })
+    const log = buildCallbackPersistFailureLog(mockRequest, errWithStatus)
+    expect(log.error.code).toBe(500)
+  })
+
+  test('falls back to persistError.code when statusCode is absent', () => {
+    const errWithCode = Object.assign(new Error('Timeout'), { code: 'ETIMEDOUT' })
+    const log = buildCallbackPersistFailureLog(mockRequest, errWithCode)
+    expect(log.error.code).toBe('ETIMEDOUT')
+  })
+
+  test('sets error.type to constructor name', () => {
+    class MongoWriteError extends Error {}
+    const log = buildCallbackPersistFailureLog(mockRequest, new MongoWriteError('write failed'))
+    expect(log.error.type).toBe('MongoWriteError')
+  })
+
+  test('does not include event.reason (auth is disabled on this route)', () => {
+    const log = buildCallbackPersistFailureLog(mockRequest, persistError)
+    expect(log.event.reason).toBeUndefined()
+    expect(Object.keys(log.event)).not.toContain('reason')
+  })
+})


### PR DESCRIPTION
Our log messages must be [ecs compliant](https://github.com/DEFRA/cdp-documentation/blob/main/how-to/logging.md?plain=1) or data wont be shown on cdp open search logs.

This PR refactors a log message for the /callback route to provide more useful data and be compliant with the ecs pattern.

This uses the ecs-logging skill i created [here](https://github.com/simonnineteen90/agent-power-ups/pull/1)