### PR TITLE
SFD2-1068 Eliminate code smells

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history required for SonarCloud to detect changes
 
       - name: Test code and Create Test Coverage Reports
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Depth 0 is required for branch-based versioning
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Test Coverage Reports
         run: |

--- a/src/api/v1/callback/validation/validate-callback-payload.js
+++ b/src/api/v1/callback/validation/validate-callback-payload.js
@@ -20,7 +20,7 @@ export async function validateCallbackPayload (payload, h) {
   // Stage 1: Contract validation — uploadStatus must be 'ready'
   if (requestPayload.uploadStatus !== 'ready') {
     await metricsCounter('callback_unexpected_status')
-    return await handleValidationFailure(requestPayload, new Error(`uploadStatus must be 'ready' but was '${requestPayload.uploadStatus}'`), undefined, h)
+    return handleValidationFailure(requestPayload, new Error(`uploadStatus must be 'ready' but was '${requestPayload.uploadStatus}'`), undefined, h)
   }
 
   // Stage 2: Contract validation — every file in the form must have fileStatus 'complete'
@@ -28,14 +28,14 @@ export async function validateCallbackPayload (payload, h) {
   for (const [, val] of Object.entries(form)) {
     if (val && typeof val === 'object' && 'fileId' in val && val.fileStatus !== 'complete') {
       await metricsCounter('callback_unexpected_status')
-      return await handleValidationFailure(requestPayload, new Error(`fileStatus must be 'complete' but was '${val.fileStatus}'`), val, h)
+      return handleValidationFailure(requestPayload, new Error(`fileStatus must be 'complete' but was '${val.fileStatus}'`), val, h)
     }
   }
 
   // Stage 3: Post-Joi semantic validation for each file upload
   const validation = validateFormFiles(form)
   if (!validation.isValid) {
-    return await handleValidationFailure(requestPayload, new Error(validation.error), validation.file, h)
+    return handleValidationFailure(requestPayload, new Error(validation.error), validation.file, h)
   }
 
   return null

--- a/src/api/v1/metadata/index.js
+++ b/src/api/v1/metadata/index.js
@@ -26,7 +26,7 @@ export const metadataRoute = {
   handler: async (request, h) => {
     try {
       // Convert sbi from URL param string to integer for database query
-      const sbi = parseInt(request.params.sbi, 10)
+      const sbi = Number.parseInt(request.params.sbi, 10)
       const documents = await getMetadataBySbi(sbi)
 
       return h.response({ data: documents }).code(httpConstants.HTTP_STATUS_OK)

--- a/src/config/formats/endpoint-path.js
+++ b/src/config/formats/endpoint-path.js
@@ -2,7 +2,7 @@ export const endpointPath = {
   name: 'endpoint-path',
   validate (value) {
     if (typeof value !== 'string') {
-      throw new Error('must be a string')
+      throw new TypeError('must be a string')
     }
     if (!value.startsWith('/')) {
       throw new Error('must start with a forward slash (/)')


### PR DESCRIPTION
# SFD2-1068 Eliminate code smells

Ticket - [SFD2-1068](https://eaflood.atlassian.net/browse/SFD2-1068)

## Description

Several code smells have been detected and CDP's QA team have reached out to us to highlight these so that we can resolve them and ensure they don't continue to exist on the platform.

## Changes

- Remove redundant use of `await` in `return` statements.
- Update use of `parseInt` to use `Number.parseInt` instead.
- Ensure use of `TypeError` for type checks.
- Update GitHub actions versions in response to this warning annotation I spotted (this now no longer appears with my included change):
<img width="1499" height="233" alt="image" src="https://github.com/user-attachments/assets/ae9654f1-5ee5-4cfb-b568-fa03b3bbbfc2" />

[SFD2-1068]: https://eaflood.atlassian.net/browse/SFD2-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ