### PR TITLE
feat(SFD-998): replace MIME type pattern validation with config-driven allowlist

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,7 @@ services:
       CDP_UPLOADER_S3_BUCKET: ${CDP_UPLOADER_S3_BUCKET:-fcp-sfd-object-processor-bucket}
       CDP_UPLOADER_S3_PATH: ${CDP_UPLOADER_S3_PATH:-scanned}
       CDP_UPLOADER_CALLBACK_URL: ${CDP_UPLOADER_CALLBACK_URL:-http://fcp-sfd-object-processor:3004/api/v1/callback}
-      CDP_UPLOADER_MIME_TYPES: ${CDP_UPLOADER_MIME_TYPES:-application/pdf,image/jpeg,image/png}
+      CDP_UPLOADER_MIME_TYPES: ${CDP_UPLOADER_MIME_TYPES:-image/png,image/jpeg,image/gif,image/tiff,application/pdf,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.ms-excel.sheet.macroEnabled.12,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-word.document.macroEnabled.12}
       CDP_UPLOADER_MAX_FILE_SIZE: ${CDP_UPLOADER_MAX_FILE_SIZE:-10485760}
       CDP_UPLOADER_TIMEOUT_MS: ${CDP_UPLOADER_TIMEOUT_MS:-30000}
       PUBLIC_API_BASE_URL: ${PUBLIC_API_BASE_URL:-http://localhost:3004}

--- a/src/api/v1/schemas/file-upload-schema.js
+++ b/src/api/v1/schemas/file-upload-schema.js
@@ -1,8 +1,8 @@
 import Joi from 'joi'
 import { schemaConsts } from '../../../constants/schemas.js'
+import { config } from '../../../config/index.js'
 
-// Basic MIME type pattern
-const mimeTypePattern = /^[a-zA-Z0-9][a-zA-Z0-9!#$&^_+-]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&^_+.-]*$/
+const allowedMimeTypes = config.get('cdpUploaderMimeTypes')
 // Base64 pattern (accept standard and URL-safe variants)
 const base64Pattern = /^(?:[A-Za-z0-9+/]+=*|[A-Za-z0-9-_]+=*)$/
 
@@ -40,20 +40,20 @@ export const fileUploadSchema = Joi.object({
     .example(schemaConsts.FILENAME_EXAMPLE).label('filename'),
 
   contentType: Joi.string()
-    .pattern(mimeTypePattern)
+    .valid(...allowedMimeTypes)
     .required()
     .description('MIME type of the uploaded file')
     .messages({
-      'string.pattern.base': '"{#label}" must be a valid MIME type'
+      'any.only': '"contentType" must be one of the allowed MIME types'
     })
     .example(schemaConsts.CONTENT_TYPE_EXAMPLE).label('contentType'),
 
   detectedContentType: Joi.string()
-    .pattern(mimeTypePattern)
+    .valid(...allowedMimeTypes)
     .required()
     .description('MIME type detected by virus scanning')
     .messages({
-      'string.pattern.base': '"{#label}" must be a valid MIME type'
+      'any.only': '"detectedContentType" must be one of the allowed MIME types'
     })
     .example(schemaConsts.DETECTED_CONTENT_TYPE_EXAMPLE).label('detectedContentType'),
 

--- a/test/integration/narrow/api/uploader/status.test.js
+++ b/test/integration/narrow/api/uploader/status.test.js
@@ -32,8 +32,8 @@ const pendingFile = {
 
 const rejectedFile = {
   fileId: 'c2d3e4f5-a6b7-4789-abcd-ef0123456789',
-  filename: 'virus.exe',
-  contentType: 'application/octet-stream',
+  filename: 'virus.pdf',
+  contentType: 'application/pdf',
   fileStatus: 'rejected',
   hasError: true,
   errorMessage: 'File rejected: virus detected'

--- a/test/unit/api/callback/schema.test.js
+++ b/test/unit/api/callback/schema.test.js
@@ -409,7 +409,7 @@ describe('callbackPayloadSchema validation', () => {
         }
       })
       expect(error).toBeDefined()
-      expect(error.details.some(d => d.path.includes('contentType') && d.type === 'string.pattern.base')).toBe(true)
+      expect(error.details.some(d => d.path.includes('contentType') && d.type === 'any.only')).toBe(true)
     })
 
     test('missing fileStatus fails validation', () => {
@@ -504,7 +504,7 @@ describe('callbackPayloadSchema validation', () => {
         }
       })
       expect(error).toBeDefined()
-      expect(error.details.some(d => d.path.includes('detectedContentType') && d.type === 'string.pattern.base')).toBe(true)
+      expect(error.details.some(d => d.path.includes('detectedContentType') && d.type === 'any.only')).toBe(true)
     })
 
     test('missing s3Key fails validation', () => {

--- a/test/unit/api/v1/callback/contract-validation.test.js
+++ b/test/unit/api/v1/callback/contract-validation.test.js
@@ -151,3 +151,92 @@ describe('fileUploadSchema Joi edge cases', () => {
     expect(result.error).toBeDefined()
   })
 })
+
+describe('All 12 allowed MIME types should pass validation', () => {
+  const baseFile = {
+    fileId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
+    filename: 'test.file',
+    fileStatus: 'complete',
+    s3Key: 'key',
+    s3Bucket: 'bucket',
+    checksumSha256: 'abc=',
+    contentLength: 1024
+  }
+
+  test('image/png passes validation', () => {
+    const file = { ...baseFile, contentType: 'image/png', detectedContentType: 'image/png' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('image/jpeg passes validation', () => {
+    const file = { ...baseFile, contentType: 'image/jpeg', detectedContentType: 'image/jpeg' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('image/gif passes validation', () => {
+    const file = { ...baseFile, contentType: 'image/gif', detectedContentType: 'image/gif' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('image/tiff passes validation', () => {
+    const file = { ...baseFile, contentType: 'image/tiff', detectedContentType: 'image/tiff' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/pdf passes validation', () => {
+    const file = { ...baseFile, contentType: 'application/pdf', detectedContentType: 'application/pdf' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/msword passes validation', () => {
+    const file = { ...baseFile, contentType: 'application/msword', detectedContentType: 'application/msword' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/vnd.openxmlformats-officedocument.wordprocessingml.document passes validation', () => {
+    const mime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    const file = { ...baseFile, contentType: mime, detectedContentType: mime }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/vnd.ms-word.document.macroEnabled.12 passes validation', () => {
+    const mime = 'application/vnd.ms-word.document.macroEnabled.12'
+    const file = { ...baseFile, contentType: mime, detectedContentType: mime }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/vnd.ms-excel passes validation', () => {
+    const file = { ...baseFile, contentType: 'application/vnd.ms-excel', detectedContentType: 'application/vnd.ms-excel' }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet passes validation', () => {
+    const mime = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    const file = { ...baseFile, contentType: mime, detectedContentType: mime }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/vnd.ms-excel.sheet.macroEnabled.12 passes validation', () => {
+    const mime = 'application/vnd.ms-excel.sheet.macroEnabled.12'
+    const file = { ...baseFile, contentType: mime, detectedContentType: mime }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('application/vnd.openxmlformats-officedocument.presentationml.presentation passes validation', () => {
+    const mime = 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+    const file = { ...baseFile, contentType: mime, detectedContentType: mime }
+    const result = fileUploadSchema.validate(file)
+    expect(result.error).toBeUndefined()
+  })
+})

--- a/test/unit/api/v1/uploader/initiate/functions.test.js
+++ b/test/unit/api/v1/uploader/initiate/functions.test.js
@@ -6,6 +6,7 @@ import { buildCdpUploaderPayload, rewriteResponseUrls } from '../../../../../../
 const { mockConfigGet } = vi.hoisted(() => ({
   mockConfigGet: vi.fn().mockImplementation((key) => {
     if (key === 'baseUrl.v1') return '/api/v1'
+    if (key === 'cdpUploaderMimeTypes') return ['application/pdf', 'image/jpeg', 'image/png']
     return null
   })
 }))

--- a/test/unit/api/v1/uploader/schemas/common.test.js
+++ b/test/unit/api/v1/uploader/schemas/common.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import Joi from 'joi'
 import {
   patterns,
@@ -9,6 +9,16 @@ import {
   uploaderResponseFields,
   mappedResponseFields
 } from '../../../../../../src/api/v1/schemas/uploader-common.js'
+
+const { mockMimeTypes } = vi.hoisted(() => ({
+  mockMimeTypes: ['application/pdf', 'image/jpeg', 'image/png']
+}))
+
+vi.mock('../../../../../../src/config/index.js', () => ({
+  config: {
+    get: (key) => key === 'cdpUploaderMimeTypes' ? mockMimeTypes : null
+  }
+}))
 
 describe('Shared Schema Components', () => {
   describe('patterns', () => {
@@ -398,13 +408,25 @@ describe('Shared Schema Components', () => {
       })
     })
 
-    test('should validate MIME types', () => {
-      const invalidMimeTypes = [
+    test('should accept all allowed MIME types for contentType', () => {
+      mockMimeTypes.forEach(contentType => {
+        const fileUpload = { ...baseFileUpload, fileStatus: 'pending', contentType, detectedContentType: contentType }
+        const result = fileUploadSchema.validate(fileUpload)
+        expect(result.error).toBeUndefined()
+      })
+    })
+
+    test('should reject MIME types not in the allowlist', () => {
+      const disallowedMimeTypes = [
         'invalid',
-        'text/'
+        'text/',
+        'text/plain',
+        'video/mp4',
+        'audio/mpeg',
+        'application/zip'
       ]
 
-      invalidMimeTypes.forEach(contentType => {
+      disallowedMimeTypes.forEach(contentType => {
         const fileUploadWithInvalidMime = { ...baseFileUpload, fileStatus: 'pending', contentType }
         const result = fileUploadSchema.validate(fileUploadWithInvalidMime)
         expect(result.error).toBeDefined()

--- a/test/unit/api/v1/uploader/status/handler.test.js
+++ b/test/unit/api/v1/uploader/status/handler.test.js
@@ -10,6 +10,7 @@ const { mockConfigGet } = vi.hoisted(() => ({
       case 'uploaderUrl': return 'http://cdp-uploader:7337'
       case 'uploaderStatusEndpoint': return '/status'
       case 'cdpUploaderTimeoutMs': return 30000
+      case 'cdpUploaderMimeTypes': return ['application/pdf', 'image/jpeg', 'image/png']
       default: return null
     }
   })


### PR DESCRIPTION
## Overview

https://eaflood.atlassian.net/browse/SFD2-998

Replaces the generic regex-based MIME type validation in `fileUploadSchema` with an explicit allowlist driven by the `cdpUploaderMimeTypes` config value. This ensures only approved file types are accepted and expands the default set of allowed types to include Office documents, TIFF, and GIF.

## Changes

- **`src/api/v1/schemas/file-upload-schema.js`** — Replaced `mimeTypePattern` regex with `Joi.valid(...allowedMimeTypes)` using the `cdpUploaderMimeTypes` config value for `contentType` and `detectedContentType` fields; updated error messages from `string.pattern.base` to `any.only`
- **`compose.yaml`** — Expanded the default `CDP_UPLOADER_MIME_TYPES` list to include GIF, TIFF, Excel (`.xls`/`.xlsx`), Word (`.doc`/`.docx`), PowerPoint (`.pptx`), and macro-enabled document formats
- **`test/unit/api/v1/uploader/schemas/common.test.js`** — Added config mock for `cdpUploaderMimeTypes`; split MIME type test into explicit accept (allowlisted types) and reject (non-allowlisted types) cases
- **`test/unit/api/callback/schema.test.js`** — Updated error type assertions from `string.pattern.base` to `any.only`
- **`test/unit/api/v1/uploader/initiate/functions.test.js`** — Added `cdpUploaderMimeTypes` to mock config
- **`test/unit/api/v1/uploader/status/handler.test.js`** — Added `cdpUploaderMimeTypes` to mock config
- **`test/integration/narrow/api/uploader/status.test.js`** — Updated `rejectedFile` to use an allowlisted content type since `application/octet-stream` is no longer valid

## Testing

All existing unit and integration tests updated to reflect the new allowlist-based validation. Tests now explicitly verify that allowlisted MIME types pass and non-allowlisted types are rejected.