### PR TITLE
chore(#sfd-1093): exclude dependabot from sonar scan

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -53,7 +53,8 @@ jobs:
           fi
 
       - name: SonarQubeScan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@v8
+        if: github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Update sonar scan and exclude dependabot from running sonar scan as 🤖 has no access to secrets

## Checklist

- [ ] has cloned repo locally
- [ ] has updated the ticket with version number
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity