### PR TITLE
FLS1-37 Validate numberOfRejectedFiles in callback payload

### DIFF
--- a/src/api/v1/callback/validation/validate-callback-payload.js
+++ b/src/api/v1/callback/validation/validate-callback-payload.js
@@ -1,6 +1,9 @@
+import { createLogger } from '../../../../logging/logger.js'
 import { metricsCounter } from '../../../common/helpers/metrics.js'
 import { validateFormFiles } from './validate-form-files.js'
 import { handleValidationFailure } from './handle-validation-failure.js'
+
+const logger = createLogger()
 
 /**
  * Validates the callback payload and form files.
@@ -23,8 +26,32 @@ export async function validateCallbackPayload (payload, h) {
     return handleValidationFailure(requestPayload, new Error(`uploadStatus must be 'ready' but was '${requestPayload.uploadStatus}'`), undefined, h)
   }
 
-  // Stage 2: Contract validation — every file in the form must have fileStatus 'complete'
+  // Observability: numberOfRejectedFiles mismatch check (lenient — warn only)
   const form = requestPayload.form || {}
+  const actualRejectedCount = Object.values(form).filter(
+    val => val && typeof val === 'object' && 'fileId' in val && val.fileStatus === 'rejected'
+  ).length
+  const declaredRejectedCount = requestPayload.numberOfRejectedFiles
+
+  if (declaredRejectedCount !== actualRejectedCount) {
+    logger.warn(
+      {
+        event: {
+          type: 'rejected_files_count_mismatch',
+          action: 'callback_validation',
+          category: 'observability',
+          outcome: 'mismatch',
+          reference: requestPayload.metadata?.uosr,
+          expected: declaredRejectedCount,
+          actual: actualRejectedCount
+        }
+      },
+      `numberOfRejectedFiles mismatch: declared=${declaredRejectedCount}, actual=${actualRejectedCount}`
+    )
+    await metricsCounter('op.callback.rejected_files_mismatch')
+  }
+
+  // Stage 2: Contract validation — every file in the form must have fileStatus 'complete'
   for (const [, val] of Object.entries(form)) {
     if (val && typeof val === 'object' && 'fileId' in val && val.fileStatus !== 'complete') {
       await metricsCounter('callback_unexpected_status')

--- a/src/api/v1/callback/validation/validate-callback-payload.js
+++ b/src/api/v1/callback/validation/validate-callback-payload.js
@@ -5,6 +5,9 @@ import { handleValidationFailure } from './handle-validation-failure.js'
 
 const logger = createLogger()
 
+const isFileEntry = (val) =>
+  val !== null && typeof val === 'object' && 'fileId' in val
+
 /**
  * Validates the callback payload and form files.
  *
@@ -29,7 +32,7 @@ export async function validateCallbackPayload (payload, h) {
   // Observability: numberOfRejectedFiles mismatch check (lenient — warn only)
   const form = requestPayload.form || {}
   const actualRejectedCount = Object.values(form).filter(
-    val => val && typeof val === 'object' && 'fileId' in val && val.fileStatus === 'rejected'
+    val => isFileEntry(val) && val.fileStatus === 'rejected'
   ).length
   const declaredRejectedCount = requestPayload.numberOfRejectedFiles
 
@@ -53,7 +56,7 @@ export async function validateCallbackPayload (payload, h) {
 
   // Stage 2: Contract validation — every file in the form must have fileStatus 'complete'
   for (const [, val] of Object.entries(form)) {
-    if (val && typeof val === 'object' && 'fileId' in val && val.fileStatus !== 'complete') {
+    if (isFileEntry(val) && val.fileStatus !== 'complete') {
       await metricsCounter('callback_unexpected_status')
       return handleValidationFailure(requestPayload, new Error(`fileStatus must be 'complete' but was '${val.fileStatus}'`), val, h)
     }

--- a/test/unit/api/v1/callback/validate-rejected-files-count.test.js
+++ b/test/unit/api/v1/callback/validate-rejected-files-count.test.js
@@ -1,0 +1,140 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+import { validateCallbackPayload } from '../../../../../src/api/v1/callback/validation/validate-callback-payload.js'
+import * as metricsModule from '../../../../../src/api/common/helpers/metrics.js'
+import { baseMetadata, baseFileUpload1 } from '../../../../mocks/base-data.js'
+
+vi.mock('../../../../../src/api/common/helpers/metrics.js', () => ({ metricsCounter: vi.fn() }))
+
+const mockLogger = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }))
+vi.mock('../../../../../src/logging/logger.js', () => ({ createLogger: () => mockLogger }))
+
+vi.mock('../../../../../src/services/metadata-service.js', () => ({
+  persistValidationFailureStatus: vi.fn().mockResolvedValue(undefined)
+}))
+
+const rejectedFile = {
+  fileId: '550e8400-e29b-41d4-a716-446655440001',
+  filename: 'infected.pdf',
+  contentType: 'application/pdf',
+  fileStatus: 'rejected',
+  hasError: true,
+  errorMessage: 'File contains virus: Trojan.Generic'
+}
+
+const mockH = {
+  response: (body) => ({ body, code: (status) => ({ status, body }) })
+}
+
+describe('numberOfRejectedFiles mismatch check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('no mismatch (declared=0, actual=0) does not log warning or emit metric', async () => {
+    const payload = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      numberOfRejectedFiles: 0,
+      form: { 'good-file': baseFileUpload1, 'text-field': 'some text' }
+    }
+
+    await validateCallbackPayload(payload, mockH)
+
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+    expect(metricsModule.metricsCounter).not.toHaveBeenCalledWith('op.callback.rejected_files_mismatch')
+  })
+
+  test('mismatch (declared=0, actual=1) logs structured warning and emits metric', async () => {
+    const payload = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      numberOfRejectedFiles: 0,
+      form: { 'bad-file': rejectedFile, 'text-field': 'some text' }
+    }
+
+    await validateCallbackPayload(payload, mockH)
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      {
+        event: {
+          type: 'rejected_files_count_mismatch',
+          action: 'callback_validation',
+          category: 'observability',
+          outcome: 'mismatch',
+          reference: baseMetadata.uosr,
+          expected: 0,
+          actual: 1
+        }
+      },
+      'numberOfRejectedFiles mismatch: declared=0, actual=1'
+    )
+    expect(metricsModule.metricsCounter).toHaveBeenCalledWith('op.callback.rejected_files_mismatch')
+  })
+
+  test('mismatch (declared=2, actual=1) logs warning with correct expected/actual values', async () => {
+    const payload = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      numberOfRejectedFiles: 2,
+      form: { 'bad-file': rejectedFile }
+    }
+
+    await validateCallbackPayload(payload, mockH)
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ expected: 2, actual: 1 })
+      }),
+      'numberOfRejectedFiles mismatch: declared=2, actual=1'
+    )
+    expect(metricsModule.metricsCounter).toHaveBeenCalledWith('op.callback.rejected_files_mismatch')
+  })
+
+  test('no mismatch (declared=1, actual=1) does not log warning or emit metric', async () => {
+    const payload = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      numberOfRejectedFiles: 1,
+      form: { 'bad-file': rejectedFile }
+    }
+
+    await validateCallbackPayload(payload, mockH)
+
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+    expect(metricsModule.metricsCounter).not.toHaveBeenCalledWith('op.callback.rejected_files_mismatch')
+  })
+
+  test('text fields in form are excluded from rejected file count', async () => {
+    const payload = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      numberOfRejectedFiles: 1,
+      form: {
+        'bad-file': rejectedFile,
+        'text-field': 'not a file',
+        'another-text': 'also not a file'
+      }
+    }
+
+    await validateCallbackPayload(payload, mockH)
+
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+    expect(metricsModule.metricsCounter).not.toHaveBeenCalledWith('op.callback.rejected_files_mismatch')
+  })
+
+  test('processing continues after mismatch — Stage 2 still handles non-complete files', async () => {
+    const payload = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      numberOfRejectedFiles: 0,
+      form: { 'bad-file': rejectedFile }
+    }
+
+    const result = await validateCallbackPayload(payload, mockH)
+
+    expect(mockLogger.warn).toHaveBeenCalled()
+    expect(result).not.toBeNull()
+    expect(result.status).toBe(201)
+  })
+})


### PR DESCRIPTION
# Summary of implementation

1. `src/api/v1/callback/validation/validate-callback-payload.js` - Added the mismatch check between Stage 1 and Stage 2:

- Imports createLogger and instantiates it at module level
- Hoists the form variable so it's available for both the check and Stage 2
- Counts actual rejected files (`fileStatus === 'rejected' with fileId`)
- On mismatch: logs a `logger.warn` with ECS-compliant event.* fields (type, action, category, outcome, reference, expected, actual) and emits the `op.callback.rejected_files_mismatch` metric
- Processing continues regardless (lenient)

2. `test/unit/api/v1/callback/validate-rejected-files-count.test.js` - 6 tests covering: 

- No mismatch (0/0): no warning, no metric
- Mismatch (declared = 0, actual = 1) - full log structure assertion + metric
- Mismatch (declared = 2, actual = 1) - log values checked
- No mismatch (1/1) - no warning, no metric
- Text fields excluded from count
- Processing continues after mismatch (Stage 2 still runs)