### PR TITLE
FLS1-29 Enforce fileId based idempotency in callback

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "docs/openapi/v1.json",
         "hashed_secret": "a97c9203c59d6537d8bbf3d25b5264848366dca7",
         "is_verified": false,
-        "line_number": 561
+        "line_number": 577
       }
     ],
     "scripts/generate-openapi.js": [
@@ -345,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T12:16:21Z"
+  "generated_at": "2026-06-03T11:01:40Z"
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -67,7 +67,7 @@
           "url": {
             "type": "string",
             "description": "Presigned URL that allows time-restricted access to a file in S3.",
-            "example": "https://my-bucket.s3.amazonaws.com/photos/cat.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20251006%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251006T121314Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=5a2e4b9c9e4b6d4b8b7a6b6f4f1d5b2c6e7d8a9e6c3f1b2e4d5a6b7c8d9e0f1a"
+            "example": "https://my-bucket.s3.amazonaws.com/photos/cat.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20251006%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251006T121314Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=5a2e4b9c9e4b6d4b8b7a6b6f4f1d5b2c6e7d8a9e6c3f1b2e4d5a6b7c8d9e0f1a"
           }
         },
         "required": [
@@ -329,7 +329,7 @@
       },
       "CdpStatusForm": {
         "type": "object",
-        "description": "Form data containing text fields, file upload objects, or arrays of file upload objects",
+        "description": "Form data containing text fields and file upload objects",
         "example": {
           "file-upload-1": {
             "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
@@ -342,22 +342,6 @@
             "s3Key": "scanned/folder/9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
             "s3Bucket": "fcp-sfd-object-processor-bucket"
           }
-        },
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/FileUpload"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FileUpload"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
         }
       },
       "MappedUploaderStatusData": {
@@ -420,7 +404,7 @@
           },
           "message": {
             "type": "string",
-            "example": "CDP Uploader request failed"
+            "example": "Upstream service request failed"
           }
         }
       },
@@ -437,7 +421,7 @@
           },
           "message": {
             "type": "string",
-            "example": "CDP Uploader request timed out"
+            "example": "Upstream service request timed out"
           }
         }
       },
@@ -530,20 +514,19 @@
         "type": "object",
         "description": "Form data containing both text fields and file uploads",
         "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/FileUpload"
-            },
-            {
-              "type": "array",
-              "items": {
+          "$ref": "#/components/schemas/FileUpload"
+        },
+        "x-meta": {
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
                 "$ref": "#/components/schemas/FileUpload"
               }
-            },
-            {
-              "type": "string"
-            }
-          ]
+            ]
+          }
         }
       },
       "CallbackPayload": {
@@ -571,6 +554,22 @@
           "metadata",
           "form"
         ]
+      },
+      "CallbackDuplicateResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Duplicate callback ignored"
+          },
+          "correlationId": {
+            "type": "string",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "x-format": {
+              "guid": true
+            }
+          }
+        }
       },
       "ids": {
         "type": "array",
@@ -739,7 +738,7 @@
       },
       "FileUpload": {
         "type": "object",
-        "description": "File upload metadata from CDP Uploader. Fields present depend on file processing state.",
+        "description": "File upload metadata from CDP Uploader",
         "properties": {
           "fileId": {
             "type": "string",
@@ -761,12 +760,10 @@
           },
           "fileStatus": {
             "type": "string",
-            "description": "Status of the file upload. Absent for unprocessed files in initiated/pending upload states.",
+            "description": "Status of the file upload",
             "example": "complete",
             "enum": [
-              "complete",
-              "rejected",
-              "pending"
+              "complete"
             ]
           },
           "contentLength": {
@@ -777,45 +774,39 @@
           },
           "checksumSha256": {
             "type": "string",
-            "description": "SHA-256 checksum of the file encoded in base64. Present for complete and rejected files.",
+            "description": "SHA-256 checksum of the file encoded in base64",
             "example": "bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c=",
             "pattern": "^[A-Za-z0-9+/]+=*$"
           },
           "detectedContentType": {
             "type": "string",
-            "description": "MIME type detected by virus scanning. Present for complete and rejected files.",
+            "description": "MIME type detected by virus scanning",
             "example": "application/pdf",
             "pattern": "^[a-zA-Z0-9][a-zA-Z0-9!#$&^_+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_+.-]*$"
           },
           "s3Key": {
             "type": "string",
-            "description": "S3 object key where the file is stored. Only present for complete files.",
+            "description": "S3 object key where the file is stored",
             "example": "scanned/folder/9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
             "minLength": 1
           },
           "s3Bucket": {
             "type": "string",
-            "description": "S3 bucket name where the file is stored. Only present for complete files.",
+            "description": "S3 bucket name where the file is stored",
             "example": "fcp-sfd-object-processor-bucket",
             "minLength": 1
-          },
-          "hasError": {
-            "type": "boolean",
-            "description": "Whether the file was rejected due to an error. Only present for rejected files.",
-            "example": true
-          },
-          "errorMessage": {
-            "type": "string",
-            "description": "Error message explaining why the file was rejected. Only present for rejected files.",
-            "example": "The selected file contains a virus",
-            "minLength": 1,
-            "maxLength": 2000
           }
         },
         "required": [
           "fileId",
           "filename",
-          "contentType"
+          "contentType",
+          "fileStatus",
+          "contentLength",
+          "checksumSha256",
+          "detectedContentType",
+          "s3Key",
+          "s3Bucket"
         ]
       }
     }
@@ -1080,10 +1071,8 @@
                             "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
                             "filename": "document.pdf",
                             "contentType": "application/pdf",
-                            "detectedContentType": "application/pdf",
-                            "checksumSha256": "bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c=",
-                            "contentLength": 11264,
                             "fileStatus": "rejected",
+                            "contentLength": 11264,
                             "hasError": true,
                             "errorMessage": "File rejected: virus detected"
                           }
@@ -1110,7 +1099,9 @@
                           "file-upload-1": {
                             "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b13",
                             "filename": "document.pdf",
-                            "contentType": "application/pdf"
+                            "contentType": "application/pdf",
+                            "detectedContentType": "application/pdf",
+                            "fileStatus": "pending"
                           }
                         }
                       }
@@ -1201,6 +1192,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallbackDuplicateResponse"
+                }
+              }
+            }
+          },
           "201": {
             "description": "Created",
             "content": {
@@ -1266,9 +1267,9 @@
     },
     "/api/v1/uploader/initiate": {
       "post": {
-        "summary": "Initiate a browser upload via CDP Uploader",
+        "summary": "Initiate a browser upload via upstream service",
         "operationId": "postApiV1UploaderInitiate",
-        "description": "Proxies initiation requests to CDP Uploader, enriching with server-side config and rewriting response URLs.",
+        "description": "Proxies initiation requests to upstream service, enriching with server-side config and rewriting response URLs.",
         "tags": [
           "uploader"
         ],

--- a/src/api/v1/callback/index.js
+++ b/src/api/v1/callback/index.js
@@ -63,6 +63,13 @@ export const uploadCallback = {
       try {
         const result = await persistMetadataWithOutbox(request.payload)
 
+        if (result.duplicate) {
+          return h.response({
+            message: 'Duplicate callback ignored',
+            correlationId: result.correlationId
+          }).code(httpConstants.HTTP_STATUS_OK)
+        }
+
         return h.response({
           message: 'Metadata created',
           count: result.insertedCount,

--- a/src/api/v1/callback/schema.js
+++ b/src/api/v1/callback/schema.js
@@ -67,6 +67,11 @@ const callbackSuccessResponseSchema = Joi.object({
   ids: Joi.array().items(Joi.string()).example(['60b8d295f1d2c916c8a5e9b7'])
 }).label('CallbackSuccessResponse')
 
+const callbackDuplicateResponseSchema = Joi.object({
+  message: Joi.string().example('Duplicate callback ignored'),
+  correlationId: Joi.string().uuid().example('550e8400-e29b-41d4-a716-446655440000')
+}).label('CallbackDuplicateResponse')
+
 const unprocessableEntityResponseSchema = Joi.object({
   statusCode: Joi.number().example(httpConstants.HTTP_STATUS_UNPROCESSABLE_ENTITY),
   error: Joi.string().example('Unprocessable Entity'),
@@ -76,4 +81,7 @@ const unprocessableEntityResponseSchema = Joi.object({
 export const callbackResponseSchema = generateResponseSchemas(
   callbackSuccessResponseSchema,
   httpConstants.HTTP_STATUS_CREATED,
-  { 422: unprocessableEntityResponseSchema })
+  {
+    200: callbackDuplicateResponseSchema,
+    422: unprocessableEntityResponseSchema
+  })

--- a/src/data/db.js
+++ b/src/data/db.js
@@ -16,11 +16,16 @@ const db = client.db(config.get('mongo.database'))
 
 const createIndexes = async () => {
   const statusCollection = config.get('mongo.collections.status')
+  const uploadMetadataCollection = config.get('mongo.collections.uploadMetadata')
 
   await db.collection(statusCollection).createIndexes([
     { key: { sbi: 1 }, name: 'status_sbi_idx' },
     { key: { timestamp: -1 }, name: 'status_timestamp_idx' },
     { key: { sbi: 1, timestamp: -1 }, name: 'status_sbi_timestamp_idx' }
+  ])
+
+  await db.collection(uploadMetadataCollection).createIndexes([
+    { key: { 'file.fileId': 1 }, name: 'metadata_fileId_idx', unique: true }
   ])
 
   logger.info('MongoDB indexes created')

--- a/src/repos/metadata.js
+++ b/src/repos/metadata.js
@@ -20,6 +20,20 @@ const getS3ReferenceByFileId = async (fileId) => {
   return document
 }
 
+const getMetadataByFileId = async (fileId) => {
+  const collection = config.get(metadataCollection)
+  const document = await db.collection(collection)
+    .findOne(
+      { 'file.fileId': fileId },
+      { projection: { messaging: 1 } })
+
+  if (document === null) {
+    throw new NotFoundError('No documents found')
+  }
+
+  return document
+}
+
 // Format the raw payload received from the CDP Uploader before saving it in the DB
 // removes any formData that is not a file upload
 // creates subdocuments to organise data
@@ -111,5 +125,6 @@ export {
   persistMetadata,
   formatInboundMetadata,
   getS3ReferenceByFileId,
+  getMetadataByFileId,
   bulkUpdatePublishedAtDate
 }

--- a/src/repos/metadata.js
+++ b/src/repos/metadata.js
@@ -5,6 +5,7 @@ import { NotFoundError } from '../errors/not-found-error.js'
 import { db } from '../data/db.js'
 
 const metadataCollection = 'mongo.collections.uploadMetadata'
+const noDocumentsFoundError = 'No documents found'
 
 const getS3ReferenceByFileId = async (fileId) => {
   const collection = config.get(metadataCollection)
@@ -14,7 +15,7 @@ const getS3ReferenceByFileId = async (fileId) => {
       { projection: { s3: 1 } }) // only return the s3Data
 
   if (document === null) {
-    throw new NotFoundError('No documents found')
+    throw new NotFoundError(noDocumentsFoundError)
   }
 
   return document
@@ -28,7 +29,7 @@ const getMetadataByFileId = async (fileId) => {
       { projection: { messaging: 1 } })
 
   if (document === null) {
-    throw new NotFoundError('No documents found')
+    throw new NotFoundError(noDocumentsFoundError)
   }
 
   return document
@@ -83,7 +84,7 @@ const getMetadataBySbi = async (sbi) => {
     .toArray()
 
   if (documents.length === 0) {
-    throw new NotFoundError('No documents found')
+    throw new NotFoundError(noDocumentsFoundError)
   }
 
   return documents

--- a/src/services/metadata-service.js
+++ b/src/services/metadata-service.js
@@ -1,13 +1,15 @@
 import { randomUUID } from 'node:crypto'
 
 import { client } from '../data/db.js'
-import { persistMetadata, formatInboundMetadata } from '../repos/metadata.js'
+import { persistMetadata, formatInboundMetadata, getMetadataByFileId } from '../repos/metadata.js'
 import { createOutboxEntries } from '../repos/outbox.js'
 import { insertStatus } from '../repos/status.js'
 import { createLogger } from '../logging/logger.js'
 import { buildValidatedStatusDocuments, buildValidationFailureStatusDocuments } from '../mappers/status.js'
 
 const logger = createLogger()
+
+const DUPLICATE_KEY_ERROR_CODE = 11000
 
 const persistMetadataWithOutbox = async (rawDocuments) => {
   const session = client.startSession()
@@ -28,6 +30,28 @@ const persistMetadataWithOutbox = async (rawDocuments) => {
       // this can be used in the response to the caller
     })
   } catch (error) {
+    if (error?.code === DUPLICATE_KEY_ERROR_CODE) {
+      const fileIds = Object.values(rawDocuments.form)
+        .filter(val => val !== null && typeof val === 'object' && 'fileId' in val)
+        .map(val => val.fileId)
+
+      const existingDocument = await getMetadataByFileId(fileIds[0])
+      const { correlationId } = existingDocument.messaging
+
+      logger.info(
+        {
+          event: {
+            type: 'duplicate_callback',
+            outcome: 'success',
+            reference: correlationId
+          }
+        },
+        'Duplicate callback received — returning existing correlationId'
+      )
+
+      return { duplicate: true, correlationId }
+    }
+
     logger.error(error, 'Failed to persist metadata with outbox')
     throw error
   } finally {

--- a/src/services/metadata-service.js
+++ b/src/services/metadata-service.js
@@ -35,6 +35,13 @@ const persistMetadataWithOutbox = async (rawDocuments) => {
         .filter(val => val !== null && typeof val === 'object' && 'fileId' in val)
         .map(val => val.fileId)
 
+      if (fileIds.length === 0) {
+        logger.error(error, 'Duplicate key error but no fileIds found in payload')
+        throw error
+      }
+
+      // All files in a single callback share the same correlationId,
+      // so we only need to look up the first to retrieve it.
       const existingDocument = await getMetadataByFileId(fileIds[0])
       const { correlationId } = existingDocument.messaging
 

--- a/test/integration/narrow/api/callback.test.js
+++ b/test/integration/narrow/api/callback.test.js
@@ -630,9 +630,15 @@ describe('when the database is unavailable', async () => {
 })
 
 describe('POST to the /api/v1/callback route — idempotency', async () => {
+  let originalCollection
+
   beforeAll(async () => {
     server = await createServer()
     await server.initialize()
+
+    originalCollection = config.get('mongo.collections.uploadMetadata')
+    config.set('mongo.collections.uploadMetadata', 'test-callback-idempotency')
+    metadataCollection = config.get('mongo.collections.uploadMetadata')
 
     // Ensure the unique index exists on the test collection
     await db.collection(metadataCollection).createIndex(
@@ -642,6 +648,8 @@ describe('POST to the /api/v1/callback route — idempotency', async () => {
   })
 
   afterAll(async () => {
+    await db.collection(metadataCollection).deleteMany({})
+    config.set('mongo.collections.uploadMetadata', originalCollection)
     if (server && typeof server.stop === 'function') {
       await server.stop()
     }

--- a/test/integration/narrow/api/callback.test.js
+++ b/test/integration/narrow/api/callback.test.js
@@ -5,6 +5,7 @@ import { db } from '../../../../src/data/db.js'
 import { config } from '../../../../src/config'
 import { createServer } from '../../../../src/api'
 import { mockScanAndUploadResponse, mockScanAndUploadResponseSingleFile } from '../../../mocks/cdp-uploader.js'
+import { baseMetadata, baseFileUpload2 } from '../../../mocks/base-data.js'
 
 let server
 let originalMetadataCollection
@@ -625,5 +626,112 @@ describe('when the database is unavailable', async () => {
     } finally {
       dbSpy.mockRestore()
     }
+  })
+})
+
+describe('POST to the /api/v1/callback route — idempotency', async () => {
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+
+    // Ensure the unique index exists on the test collection
+    await db.collection(metadataCollection).createIndex(
+      { 'file.fileId': 1 },
+      { name: 'metadata_fileId_idx', unique: true }
+    )
+  })
+
+  afterAll(async () => {
+    if (server && typeof server.stop === 'function') {
+      await server.stop()
+    }
+  })
+
+  test('first callback succeeds and creates records', async () => {
+    const beforeMetadataCount = await db.collection(metadataCollection).countDocuments()
+    const beforeOutboxCount = await db.collection(outboxCollection).countDocuments()
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/callback',
+      payload: mockScanAndUploadResponseSingleFile
+    })
+
+    const afterMetadataCount = await db.collection(metadataCollection).countDocuments()
+    const afterOutboxCount = await db.collection(outboxCollection).countDocuments()
+
+    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_CREATED)
+    expect(afterMetadataCount - beforeMetadataCount).toBe(1)
+    expect(afterOutboxCount - beforeOutboxCount).toBe(1)
+  })
+
+  test('duplicate callback returns 200 with existing correlationId and creates no new records', async () => {
+    // Insert once
+    await server.inject({
+      method: 'POST',
+      url: '/api/v1/callback',
+      payload: mockScanAndUploadResponseSingleFile
+    })
+
+    const beforeMetadataCount = await db.collection(metadataCollection).countDocuments()
+    const beforeOutboxCount = await db.collection(outboxCollection).countDocuments()
+
+    // Get the correlationId from the first insert
+    const firstDoc = await db.collection(metadataCollection).findOne(
+      { 'file.fileId': mockScanAndUploadResponseSingleFile.form['single-file'].fileId },
+      { projection: { messaging: 1 } }
+    )
+    const existingCorrelationId = firstDoc.messaging.correlationId
+
+    // Send duplicate
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/callback',
+      payload: mockScanAndUploadResponseSingleFile
+    })
+
+    const afterMetadataCount = await db.collection(metadataCollection).countDocuments()
+    const afterOutboxCount = await db.collection(outboxCollection).countDocuments()
+
+    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
+    expect(response.result.message).toBe('Duplicate callback ignored')
+    expect(response.result.correlationId).toBe(existingCorrelationId)
+
+    // No new records created
+    expect(afterMetadataCount).toBe(beforeMetadataCount)
+    expect(afterOutboxCount).toBe(beforeOutboxCount)
+  })
+
+  test('different fileId is processed normally and creates new records', async () => {
+    // Insert once with single-file payload (uses baseFileUpload1)
+    await server.inject({
+      method: 'POST',
+      url: '/api/v1/callback',
+      payload: mockScanAndUploadResponseSingleFile
+    })
+
+    const beforeMetadataCount = await db.collection(metadataCollection).countDocuments()
+    const beforeOutboxCount = await db.collection(outboxCollection).countDocuments()
+
+    // Build a payload with a different fileId (baseFileUpload2)
+    const payloadWithDifferentFile = {
+      uploadStatus: 'ready',
+      metadata: baseMetadata,
+      form: { 'other-file': baseFileUpload2 },
+      numberOfRejectedFiles: 0
+    }
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/callback',
+      payload: payloadWithDifferentFile
+    })
+
+    const afterMetadataCount = await db.collection(metadataCollection).countDocuments()
+    const afterOutboxCount = await db.collection(outboxCollection).countDocuments()
+
+    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_CREATED)
+    expect(afterMetadataCount - beforeMetadataCount).toBe(1)
+    expect(afterOutboxCount - beforeOutboxCount).toBe(1)
   })
 })

--- a/test/unit/api/callback/handler-status.test.js
+++ b/test/unit/api/callback/handler-status.test.js
@@ -72,4 +72,30 @@ describe('callback handler status enforcement', () => {
     // Rejected files should trigger unexpected-status metric since fileStatus !== 'complete'
     expect(metricsModule.metricsCounter).toHaveBeenCalledWith('callback_unexpected_status')
   })
+
+  test('duplicate callback returns 200 with existing correlationId', async () => {
+    const payload = { ...mockScanAndUploadResponse, uploadStatus: 'ready' }
+    const existingCorrelationId = '123e4567-e89b-12d3-a456-426655440000'
+
+    metadataService.persistMetadataWithOutbox.mockResolvedValue({
+      duplicate: true,
+      correlationId: existingCorrelationId
+    })
+
+    const h = {
+      response: (body) => ({
+        body,
+        code: (status) => ({ status, body })
+      })
+    }
+
+    const result = await uploadCallback.options.handler({ payload }, h)
+
+    expect(metadataService.persistMetadataWithOutbox).toHaveBeenCalledWith(payload)
+    expect(result.status).toBe(200)
+    expect(result.body).toEqual({
+      message: 'Duplicate callback ignored',
+      correlationId: existingCorrelationId
+    })
+  })
 })

--- a/test/unit/services/metadata-service.test.js
+++ b/test/unit/services/metadata-service.test.js
@@ -9,11 +9,11 @@ import {
   buildValidationFailureStatusDocuments,
   buildValidatedStatusDocuments
 } from '../../../src/mappers/status.js'
-import { persistMetadata, formatInboundMetadata } from '../../../src/repos/metadata.js'
+import { persistMetadata, formatInboundMetadata, getMetadataByFileId } from '../../../src/repos/metadata.js'
 import { createOutboxEntries } from '../../../src/repos/outbox.js'
 import { insertStatus } from '../../../src/repos/status.js'
 import { client } from '../../../src/data/db.js'
-import { mockScanAndUploadResponseArray as rawDocuments } from '../../mocks/cdp-uploader.js'
+import { mockScanAndUploadResponseArray as rawDocuments, mockScanAndUploadResponse } from '../../mocks/cdp-uploader.js'
 import { mockFormattedDocuments as formattedDocuments } from '../../mocks/metadata.js'
 
 vi.mock('../../../src/repos/metadata.js')
@@ -224,6 +224,52 @@ describe('Metadata Service', () => {
         ]),
         mockSession
       )
+    })
+
+    test('should return duplicate indicator and correlationId on E11000 duplicate key error', async () => {
+      const existingCorrelationId = '123e4567-e89b-12d3-a456-426655440000'
+      const duplicateKeyError = Object.assign(new Error('E11000 duplicate key error'), { code: 11000 })
+
+      mockSession.withTransaction.mockRejectedValue(duplicateKeyError)
+      getMetadataByFileId.mockResolvedValue({ messaging: { correlationId: existingCorrelationId } })
+
+      const result = await persistMetadataWithOutbox(mockScanAndUploadResponse)
+
+      expect(result).toEqual({ duplicate: true, correlationId: existingCorrelationId })
+      expect(getMetadataByFileId).toHaveBeenCalled()
+    })
+
+    test('should end session on E11000 duplicate key error', async () => {
+      const existingCorrelationId = '123e4567-e89b-12d3-a456-426655440000'
+      const duplicateKeyError = Object.assign(new Error('E11000 duplicate key error'), { code: 11000 })
+
+      mockSession.withTransaction.mockRejectedValue(duplicateKeyError)
+      getMetadataByFileId.mockResolvedValue({ messaging: { correlationId: existingCorrelationId } })
+
+      await persistMetadataWithOutbox(mockScanAndUploadResponse)
+
+      expect(mockSession.endSession).toHaveBeenCalled()
+    })
+
+    test('should not create outbox entries on E11000 duplicate key error', async () => {
+      const existingCorrelationId = '123e4567-e89b-12d3-a456-426655440000'
+      const duplicateKeyError = Object.assign(new Error('E11000 duplicate key error'), { code: 11000 })
+
+      mockSession.withTransaction.mockRejectedValue(duplicateKeyError)
+      getMetadataByFileId.mockResolvedValue({ messaging: { correlationId: existingCorrelationId } })
+
+      await persistMetadataWithOutbox(mockScanAndUploadResponse)
+
+      expect(createOutboxEntries).not.toHaveBeenCalled()
+    })
+
+    test('should rethrow non-duplicate errors', async () => {
+      const genericError = new Error('Some other database error')
+
+      mockSession.withTransaction.mockRejectedValue(genericError)
+
+      await expect(persistMetadataWithOutbox(rawDocuments)).rejects.toThrow('Some other database error')
+      expect(getMetadataByFileId).not.toHaveBeenCalled()
     })
   })
 

--- a/test/unit/services/metadata-service.test.js
+++ b/test/unit/services/metadata-service.test.js
@@ -271,6 +271,23 @@ describe('Metadata Service', () => {
       await expect(persistMetadataWithOutbox(rawDocuments)).rejects.toThrow('Some other database error')
       expect(getMetadataByFileId).not.toHaveBeenCalled()
     })
+
+    test('should rethrow E11000 error if no fileIds found in payload', async () => {
+      const duplicateKeyError = Object.assign(new Error('E11000 duplicate key error'), { code: 11000 })
+      const payloadWithNoFiles = {
+        uploadStatus: 'ready',
+        metadata: { crn: 1234567890 },
+        form: {
+          'text-field': 'just a string',
+          'another-field': 'also not a file'
+        }
+      }
+
+      mockSession.withTransaction.mockRejectedValue(duplicateKeyError)
+
+      await expect(persistMetadataWithOutbox(payloadWithNoFiles)).rejects.toThrow('E11000 duplicate key error')
+      expect(getMetadataByFileId).not.toHaveBeenCalled()
+    })
   })
 
   describe('persistValidationFailureStatus', () => {


### PR DESCRIPTION
# FLS1-29 Enforce `fileId` based idempotency in callback

Ticket - [FLS1-29](https://eaflood.atlassian.net/browse/FLS1-29)  

## Summary  

Ensuring idempotency based on the `fileId` will prevent duplicate metadata records being created when the CDP uploader calls the callback endpoint more than once with the same `fileId`.

## Changes

| File | Change |
|------|--------|
| `src/data/db.js` | Add unique index in `createIndexes()` |
| `src/repos/metadata.js` | Add `getMetadataByFileId()` |
| `src/services/metadata-service.js` | Catch E11000, return duplicate indicator |
| `src/api/v1/callback/index.js` | Return 200 on duplicate |
| `src/api/v1/callback/schema.js` | Add 200 response schema |
| `docs/openapi/v1.json` | Regenerated (auto-generated from hapi-swagger) |
| `test/unit/services/metadata-service.test.js` | Duplicate path tests |
| `test/unit/api/callback/handler-status.test.js` | 200 response tests |
| `test/integration/narrow/api/callback.test.js` | Idempotency integration tests |


[FLS1-29]: https://eaflood.atlassian.net/browse/FLS1-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ