### PR TITLE
fix(#fls1-60): decouple internal and external cdp-uploader urls

### DIFF
--- a/src/api/v1/uploader/initiate/index.js
+++ b/src/api/v1/uploader/initiate/index.js
@@ -24,10 +24,10 @@ export const buildCdpUploaderPayload = (clientPayload) => {
 
 export const rewriteResponseUrls = (cdpResponse) => {
   const { uploadId } = cdpResponse
-  const uploaderUrl = config.get('uploaderUrl')
+  const externalUrl = config.get('uploaderExternalUrl') || config.get('uploaderUrl')
   return {
     uploadId,
-    uploadUrl: `${uploaderUrl}/upload-and-scan/${uploadId}`,
+    uploadUrl: `${externalUrl}/upload-and-scan/${uploadId}`,
     statusUrl: `${baseUrl}/uploader/status/${uploadId}`
   }
 }

--- a/src/config/uploader.js
+++ b/src/config/uploader.js
@@ -1,10 +1,17 @@
 export const uploaderConfig = {
   uploaderUrl: {
-    doc: 'The base URL for the cdp uploader api',
+    doc: 'The internal base URL for server-to-server calls to the cdp uploader api',
     format: String,
     nullable: false,
     default: null,
     env: 'CDP_UPLOADER_URL'
+  },
+  uploaderExternalUrl: {
+    doc: 'The external base URL for cdp uploader exposed to browser clients. Falls back to CDP_UPLOADER_URL if not set.',
+    format: String,
+    nullable: true,
+    default: null,
+    env: 'CDP_UPLOADER_EXTERNAL_URL'
   },
   uploaderInitiateEndpoint: {
     doc: 'The endpoint path for initiating document scans',

--- a/test/unit/api/uploader/initiate.test.js
+++ b/test/unit/api/uploader/initiate.test.js
@@ -24,6 +24,7 @@ const mockCdpUploaderResponse = {
 const mockConfigValues = {
   'baseUrl.v1': '/api/v1',
   uploaderUrl: 'http://cdp-uploader:7337',
+  uploaderExternalUrl: null,
   uploaderInitiateEndpoint: '/initiate',
   cdpUploaderS3Bucket: 'test-bucket',
   cdpUploaderS3Path: 'uploads',

--- a/test/unit/api/v1/uploader/initiate/functions.test.js
+++ b/test/unit/api/v1/uploader/initiate/functions.test.js
@@ -132,30 +132,48 @@ describe('Uploader Initiate Functions', () => {
     beforeEach(() => {
       mockConfigGet.mockImplementation((key) => {
         switch (key) {
-          case 'uploaderUrl': return 'http://cdp-uploader:7337'
-          case 'baseUrl.v1': return '/api/v1'
-          default: return null
-        }
-      })
-    })
+         case 'uploaderExternalUrl': return null
+         case 'uploaderUrl': return 'http://cdp-uploader:7337'
+         case 'baseUrl.v1': return '/api/v1'
+         default: return null
+       }
+     })
+   })
 
-    test('should rewrite URLs correctly', () => {
-      const cdpResponse = {
-        uploadId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
-        originalUploadUrl: 'http://cdp-uploader:7337/upload/9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
-        originalStatusUrl: 'http://cdp-uploader:7337/status/9fcaabe5-77ec-44db-8356-3a6e8dc51b13'
-      }
+   test('should rewrite URLs correctly using uploaderUrl as fallback', () => {
+     const cdpResponse = {
+       uploadId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
+       originalUploadUrl: 'http://cdp-uploader:7337/upload/9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
+       originalStatusUrl: 'http://cdp-uploader:7337/status/9fcaabe5-77ec-44db-8356-3a6e8dc51b13'
+     }
 
-      const result = rewriteResponseUrls(cdpResponse)
+     const result = rewriteResponseUrls(cdpResponse)
 
-      expect(result).toEqual({
-        uploadId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
-        uploadUrl: 'http://cdp-uploader:7337/upload-and-scan/9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
-        statusUrl: '/api/v1/uploader/status/9fcaabe5-77ec-44db-8356-3a6e8dc51b13'
-      })
+     expect(result).toEqual({
+       uploadId: '9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
+       uploadUrl: 'http://cdp-uploader:7337/upload-and-scan/9fcaabe5-77ec-44db-8356-3a6e8dc51b13',
+       statusUrl: '/api/v1/uploader/status/9fcaabe5-77ec-44db-8356-3a6e8dc51b13'
+     })
 
-      expect(mockConfigGet).toHaveBeenCalledWith('uploaderUrl')
-    })
+     expect(mockConfigGet).toHaveBeenCalledWith('uploaderExternalUrl')
+     expect(mockConfigGet).toHaveBeenCalledWith('uploaderUrl')
+   })
+
+   test('should use uploaderExternalUrl when set', () => {
+     mockConfigGet.mockImplementation((key) => {
+       switch (key) {
+         case 'uploaderExternalUrl': return 'https://upload-file.ext-test.cdp.defra.gov.uk'
+         case 'uploaderUrl': return 'https://cdp-uploader.ext-test.cdp-int.defra.cloud'
+         case 'baseUrl.v1': return '/api/v1'
+         default: return null
+       }
+     })
+
+     const cdpResponse = { uploadId: 'test-upload-id' }
+     const result = rewriteResponseUrls(cdpResponse)
+
+     expect(result.uploadUrl).toBe('https://upload-file.ext-test.cdp.defra.gov.uk/upload-and-scan/test-upload-id')
+   })
 
     test('should handle different uploadIds', () => {
       const testUploadIds = [

--- a/test/unit/config/uploader.test.js
+++ b/test/unit/config/uploader.test.js
@@ -4,10 +4,18 @@ import { uploaderConfig } from '../../../src/config/uploader.js'
 describe('uploaderConfig', () => {
   test('should have uploaderUrl field', () => {
     expect(uploaderConfig.uploaderUrl).toBeDefined()
-    expect(uploaderConfig.uploaderUrl.doc).toBe('The base URL for the cdp uploader api')
+    expect(uploaderConfig.uploaderUrl.doc).toBe('The internal base URL for server-to-server calls to the cdp uploader api')
     expect(uploaderConfig.uploaderUrl.format).toBe(String)
     expect(uploaderConfig.uploaderUrl.nullable).toBe(false)
     expect(uploaderConfig.uploaderUrl.env).toBe('CDP_UPLOADER_URL')
+  })
+
+  test('should have uploaderExternalUrl field', () => {
+    expect(uploaderConfig.uploaderExternalUrl).toBeDefined()
+    expect(uploaderConfig.uploaderExternalUrl.doc).toBe('The external base URL for cdp uploader exposed to browser clients. Falls back to CDP_UPLOADER_URL if not set.')
+    expect(uploaderConfig.uploaderExternalUrl.format).toBe(String)
+    expect(uploaderConfig.uploaderExternalUrl.nullable).toBe(true)
+    expect(uploaderConfig.uploaderExternalUrl.env).toBe('CDP_UPLOADER_EXTERNAL_URL')
   })
 
   test('should have uploaderInitiateEndpoint field with default', () => {
@@ -29,7 +37,7 @@ describe('uploaderConfig', () => {
   })
 
   test('should have all required fields', () => {
-    const requiredFields = ['uploaderUrl', 'uploaderInitiateEndpoint', 'uploaderStatusEndpoint']
+    const requiredFields = ['uploaderUrl', 'uploaderExternalUrl', 'uploaderInitiateEndpoint', 'uploaderStatusEndpoint']
     requiredFields.forEach(field => {
       expect(uploaderConfig[field]).toBeDefined()
     })
@@ -45,6 +53,10 @@ describe('uploaderConfig', () => {
 
   test('should reject null uploaderUrl', () => {
     expect(uploaderConfig.uploaderUrl.nullable).toBe(false)
+  })
+
+  test('should allow null uploaderExternalUrl', () => {
+    expect(uploaderConfig.uploaderExternalUrl.nullable).toBe(true)
   })
 
   test('endpoints should require string format', () => {


### PR DESCRIPTION
# Description

Prevent server-to-server requests from fcp-sfd-object-processor to cdp-uploader from routing through the public API gateway, which causes timeouts and retry failures when the service configuration mistakenly uses an external URL for internal calls. 

Browser clients will continue to receive the correct external URL for upload operations.

## Checklist

- [ ] has cloned repo locally
- [ ] has updated the ticket with version number
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity