### PR TITLE
feat: extend audit wrapper with optional per-call ip override

### DIFF
--- a/src/messaging/outbound/audit/publish-audit-event.js
+++ b/src/messaging/outbound/audit/publish-audit-event.js
@@ -16,9 +16,9 @@ const auditPublishConfig = {
   ip: '0.0.0.0'
 }
 
-export const publishAuditEvent = async (event) => {
+export const publishAuditEvent = async (event, { ip } = {}) => {
   try {
-    await _publishAuditEvent(event, auditPublishConfig)
+    await _publishAuditEvent(event, { ...auditPublishConfig, ...(ip && { ip }) })
   } catch (err) {
     logger.error(
       { event: { type: 'audit_publish_failed', outcome: 'failure', reason: err.message } },

--- a/test/unit/messaging/outbound/audit/publish-audit-event.test.js
+++ b/test/unit/messaging/outbound/audit/publish-audit-event.test.js
@@ -53,6 +53,30 @@ describe('publishAuditEvent', () => {
     )
   })
 
+  test('should use provided ip when given', async () => {
+    const { publishAuditEvent: _publishAuditEvent } = await import('@defra/fcp-audit-publisher')
+    const { publishAuditEvent } = await import('../../../../../src/messaging/outbound/audit/publish-audit-event.js')
+
+    await publishAuditEvent(mockAuditEvent, { ip: '10.0.0.1' })
+
+    expect(_publishAuditEvent).toHaveBeenCalledWith(
+      mockAuditEvent,
+      expect.objectContaining({ ip: '10.0.0.1' })
+    )
+  })
+
+  test('should fall back to default ip when none provided', async () => {
+    const { publishAuditEvent: _publishAuditEvent } = await import('@defra/fcp-audit-publisher')
+    const { publishAuditEvent } = await import('../../../../../src/messaging/outbound/audit/publish-audit-event.js')
+
+    await publishAuditEvent(mockAuditEvent)
+
+    expect(_publishAuditEvent).toHaveBeenCalledWith(
+      mockAuditEvent,
+      expect.objectContaining({ ip: '0.0.0.0' })
+    )
+  })
+
   test('should not throw when publishAuditEvent rejects', async () => {
     const { publishAuditEvent: _publishAuditEvent } = await import('@defra/fcp-audit-publisher')
     const { publishAuditEvent } = await import('../../../../../src/messaging/outbound/audit/publish-audit-event.js')


### PR DESCRIPTION
## Summary
- Adds an optional `{ ip }` second parameter to `publishAuditEvent` so callers can pass `request.info.remoteAddress`
- Falls back to the existing static `'0.0.0.0'` default when no ip is provided
- Foundation for FLS1-21 audit events PRs — subsequent PRs (success path, failure path, outbox, security) all depend on this

## Test plan
- [ ] `npx vitest run test/unit/messaging/outbound/audit/publish-audit-event.test.js` — 5 tests pass (3 existing + 2 new for ip override)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)