### PR TITLE
FLS1-59 Expand supported CRM queue types in object processor

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "docs/openapi/v1.json",
         "hashed_secret": "a97c9203c59d6537d8bbf3d25b5264848366dca7",
         "is_verified": false,
-        "line_number": 577
+        "line_number": 591
       }
     ],
     "scripts/generate-openapi.js": [
@@ -345,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-09T12:32:33Z"
+  "generated_at": "2026-06-29T14:17:50Z"
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -435,6 +435,29 @@
           "ready"
         ]
       },
+      "type": {
+        "type": "string",
+        "description": "Type of submission - determines CRM queue",
+        "example": "CS_Agreement_Evidence",
+        "enum": [
+          "Delinked_Amendment",
+          "Delinked_Evidence",
+          "ES_Agreement_Amendment",
+          "ES_Claim",
+          "ES_Claim_Evidence",
+          "SFI_Expanded_Offer_Evidence",
+          "SFI_23_Evidence",
+          "SFI_Pilot_Evidence",
+          "CS_Facilitation_Fund_Evidence",
+          "CS_Facilitation_Fund_Amendment",
+          "CS_Application_Declaration",
+          "CS_Application_Evidence",
+          "CS_Agreement_Amendment",
+          "CS_Agreement_Evidence",
+          "CS_Revenue_Claim_Amendment",
+          "CS_Revenue_Claim_Evidence"
+        ]
+      },
       "service": {
         "type": "string",
         "description": "Source system that initiated the upload",
@@ -444,17 +467,8 @@
           "rps-portal"
         ]
       },
-      "type": {
-        "type": "string",
-        "description": "Type of submission - determines CRM queue",
-        "example": "CS_Agreement_Evidence",
-        "enum": [
-          "CS_Agreement_Evidence"
-        ]
-      },
-      "UploadMetadata": {
+      "metadata": {
         "type": "object",
-        "description": "Metadata about the upload submission",
         "properties": {
           "sbi": {
             "type": "integer",
@@ -482,6 +496,9 @@
             "description": "Unique identifier for the submission",
             "example": "1733826312"
           },
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
           "reference": {
             "type": "string",
             "description": "User-entered reference for the submission",
@@ -494,9 +511,6 @@
             "type": "string",
             "description": "Unique Object Storage Reference combining SBI and submission ID",
             "example": "105000000_1733826312"
-          },
-          "type": {
-            "$ref": "#/components/schemas/type"
           }
         },
         "required": [
@@ -504,10 +518,10 @@
           "crn",
           "frn",
           "submissionId",
+          "type",
           "reference",
           "service",
-          "uosr",
-          "type"
+          "uosr"
         ]
       },
       "CallbackForm": {
@@ -537,7 +551,7 @@
             "$ref": "#/components/schemas/UploadSessionStatus"
           },
           "metadata": {
-            "$ref": "#/components/schemas/UploadMetadata"
+            "$ref": "#/components/schemas/metadata"
           },
           "form": {
             "$ref": "#/components/schemas/CallbackForm"
@@ -645,9 +659,7 @@
             "example": "1733826312"
           },
           "type": {
-            "type": "string",
-            "description": "Type of submission - determines CRM queue",
-            "example": "CS_Agreement_Evidence"
+            "$ref": "#/components/schemas/type"
           },
           "reference": {
             "type": "string",

--- a/src/api/v1/schemas/uploader-common.js
+++ b/src/api/v1/schemas/uploader-common.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { schemaConsts } from '../../../constants/schemas.js'
+import { schemaConsts, VALID_CASE_TYPES } from '../../../constants/schemas.js'
 import { mimeTypePattern } from '../../../constants/mime-types.js'
 
 // Common validation patterns used across schemas
@@ -69,11 +69,11 @@ export const submissionFields = {
     .example(schemaConsts.SUBMISSION_ID_EXAMPLE),
 
   type: Joi.string()
-    .valid(schemaConsts.TYPE_EXAMPLE)
+    .valid(...VALID_CASE_TYPES)
     .required()
     .description('Type of submission - determines CRM queue')
     .messages({
-      'any.only': 'type must be CS_Agreement_Evidence',
+      'any.only': 'type must be a recognised CRM queue type',
       'any.required': 'type is required'
     })
     .example(schemaConsts.TYPE_EXAMPLE),

--- a/src/constants/schemas.js
+++ b/src/constants/schemas.js
@@ -35,3 +35,22 @@ export const schemaConsts = {
   S3_BUCKET_EXAMPLE: 'fcp-sfd-object-processor-bucket',
   NUMBER_OF_REJECTED_FILES_EXAMPLE: 0
 }
+
+export const VALID_CASE_TYPES = [
+  'Delinked_Amendment',
+  'Delinked_Evidence',
+  'ES_Agreement_Amendment',
+  'ES_Claim',
+  'ES_Claim_Evidence',
+  'SFI_Expanded_Offer_Evidence',
+  'SFI_23_Evidence',
+  'SFI_Pilot_Evidence',
+  'CS_Facilitation_Fund_Evidence',
+  'CS_Facilitation_Fund_Amendment',
+  'CS_Application_Declaration',
+  'CS_Application_Evidence',
+  'CS_Agreement_Amendment',
+  'CS_Agreement_Evidence',
+  'CS_Revenue_Claim_Amendment',
+  'CS_Revenue_Claim_Evidence'
+]

--- a/test/unit/api/v1/schemas/uploader-common.test.js
+++ b/test/unit/api/v1/schemas/uploader-common.test.js
@@ -30,11 +30,32 @@ describe('baseMetadataSchema — type field', () => {
     expect(error).toBeUndefined()
   })
 
+  test.each([
+    'Delinked_Amendment',
+    'Delinked_Evidence',
+    'ES_Agreement_Amendment',
+    'ES_Claim',
+    'ES_Claim_Evidence',
+    'SFI_Expanded_Offer_Evidence',
+    'SFI_23_Evidence',
+    'SFI_Pilot_Evidence',
+    'CS_Facilitation_Fund_Evidence',
+    'CS_Facilitation_Fund_Amendment',
+    'CS_Application_Declaration',
+    'CS_Application_Evidence',
+    'CS_Agreement_Amendment',
+    'CS_Revenue_Claim_Amendment',
+    'CS_Revenue_Claim_Evidence'
+  ])('accepts %s', (type) => {
+    const { error } = baseMetadataSchema.validate({ ...validMetadata, type })
+    expect(error).toBeUndefined()
+  })
+
   test('rejects an invalid type value', () => {
     const { error } = baseMetadataSchema.validate({ ...validMetadata, type: 'INVALID_TYPE' })
     expect(error).toBeDefined()
     expect(error.details[0].type).toBe('any.only')
-    expect(error.message).toContain('type must be CS_Agreement_Evidence')
+    expect(error.message).toContain('type must be a recognised CRM queue type')
   })
 
   test('rejects an empty type string', () => {


### PR DESCRIPTION
## Summary

Expands the `/api/v1/callback` endpoint to accept all 16 CRM queue types used across DEFRA farming schemes, replacing the previous single-value (`CS_Agreement_Evidence`) restriction.

### Changes

- **`src/constants/schemas.js`** — Added `VALID_CASE_TYPES` array with all 16 queue types (Delinked, ES, SFI, CS)
- **`src/api/v1/schemas/uploader-common.js`** — Switched `type` validation from `.valid(TYPE_EXAMPLE)` to `.valid(...VALID_CASE_TYPES)`; updated error message to generic `'type must be a recognised CRM queue type'`
- **`test/unit/api/v1/schemas/uploader-common.test.js`** — Added `test.each` covering all 16 valid types and updated invalid-type assertion
- **`docs/openapi/v1.json`** — Expanded `type` enum to list all 16 values

### Queue types now supported

| Scheme | Types |
|--------|-------|
| Delinked | `Delinked_Amendment`, `Delinked_Evidence` |
| ES | `ES_Agreement_Amendment`, `ES_Claim`, `ES_Claim_Evidence` |
| SFI | `SFI_Expanded_Offer_Evidence`, `SFI_23_Evidence`, `SFI_Pilot_Evidence` |
| CS | `CS_Facilitation_Fund_Evidence`, `CS_Facilitation_Fund_Amendment`, `CS_Application_Declaration`, `CS_Application_Evidence`, `CS_Agreement_Amendment`, `CS_Agreement_Evidence`, `CS_Revenue_Claim_Amendment`, `CS_Revenue_Claim_Evidence` |

