### PR TITLE
chore(dependabot): change daily schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore"
     groups:


### PR DESCRIPTION
## Summary
- update Dependabot schedule entries from daily to weekly
- no other configuration changes

## Validation
- config updated in .github/dependabot.yml