### PR TITLE
Fix: correct blob endpoint path from /blobs to /blob in SNS messages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,7 +250,7 @@ Messages published to SNS follow **CloudEvents v1.0** specification. Contract de
       fileId: 'uuid',
       fileName: 'document.pdf',
       contentType: 'application/pdf',
-      url: 'https://fcp-placeholder.cdp-int.defra.cloud/api/v1/blobs/{fileId}'
+      url: 'https://fcp-placeholder.cdp-int.defra.cloud/api/v1/blob/{fileId}'
     },
     sbi: 123456789,              // Single Business Identifier
     sourceSystem: 'fcp-sfd-frontend',  // Or 'rps-portal'

--- a/src/messaging/outbound/crm/doc-upload/build-document-upload-message-batch.js
+++ b/src/messaging/outbound/crm/doc-upload/build-document-upload-message-batch.js
@@ -34,7 +34,7 @@ export const buildDocumentUploadMessageBatch = (pendingMessages) => {
           fileId: file.fileId,
           fileName: file.filename,
           contentType: file.contentType,
-          url: `${baseUrl}/api/v1/blobs/${file.fileId}`
+          url: `${baseUrl}/api/v1/blob/${file.fileId}`
         },
         sbi: metadata.sbi,
         sourceSystem: metadata.service,

--- a/test/mocks/messaging/document-upload-event.js
+++ b/test/mocks/messaging/document-upload-event.js
@@ -26,7 +26,7 @@ export const mockDocumentUploadedEvent = {
       fileId: '123e4567-e89b-12d3-a456-426655440001',
       fileName: 'receipt.pdf',
       contentType: 'application/pdf',
-      url: 'https://mock-public-api-base-url/api/v1/blobs/123e4567-e89b-12d3-a456-426655440001'
+      url: 'https://mock-public-api-base-url/api/v1/blob/123e4567-e89b-12d3-a456-426655440001'
     },
     sbi: 123456789,
     sourceSystem: 'fcp-sfd-frontend',

--- a/test/unit/messaging/outbound/build-document-upload-message-batch.test.js
+++ b/test/unit/messaging/outbound/build-document-upload-message-batch.test.js
@@ -110,7 +110,7 @@ describe('buildDocumentUploadMessageBatch', () => {
     })
 
     test('should set data.file.url from file.fileId', () => {
-      expect(result[0].data.file.url).toBe(`https://mock-public-api-base-url/api/v1/blobs/${file.fileId}`)
+      expect(result[0].data.file.url).toBe(`https://mock-public-api-base-url/api/v1/blob/${file.fileId}`)
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS1-90