### PR TITLE
fix(#fls1-134): fix polling for rejected file type

### DIFF
--- a/src/api/v1/uploader/status/schema.js
+++ b/src/api/v1/uploader/status/schema.js
@@ -26,7 +26,11 @@ export const uploaderStatusParamsSchema = Joi.object({
  * - Unprocessed (initiated/early pending): only fileId, filename, contentType
  * - Pending scan: fileStatus: 'pending' added, other fields still absent
  * - Complete: all fields present
- * - Rejected: includes detectedContentType, checksumSha256, hasError, errorMessage
+ * - Rejected: includes hasError, errorMessage, errorCode, errorParams.
+ *   For wrong-MIME-type rejections, contentType will be the disallowed type
+ *   (e.g. application/zip), so the allowedMimeTypes constraint is relaxed for
+ *   rejected files. detectedContentType is absent (file was never uploaded),
+ *   but is also relaxed in case cdp-uploader populates it in future.
  */
 const cdpStatusFileBaseSchema = Joi.object({
   fileId: Joi.string()
@@ -41,16 +45,17 @@ const cdpStatusFileBaseSchema = Joi.object({
     .description('Original name of the uploaded file')
     .label('filename'),
 
-  contentType: Joi.string()
-    .valid(...allowedMimeTypes)
-    .required()
-    .description('MIME type of the uploaded file')
-    .label('contentType'),
+  contentType: Joi.alternatives().conditional('fileStatus', {
+    is: 'rejected',
+    then: Joi.string().min(1).required().description('MIME type of the uploaded file (any value for rejected files)'),
+    otherwise: Joi.string().valid(...allowedMimeTypes).required().description('MIME type of the uploaded file')
+  }).label('contentType'),
 
-  detectedContentType: Joi.string()
-    .valid(...allowedMimeTypes)
-    .description('MIME type detected by virus scanning')
-    .label('detectedContentType'),
+  detectedContentType: Joi.alternatives().conditional('fileStatus', {
+    is: 'rejected',
+    then: Joi.string().min(1).description('MIME type detected by virus scanning (any value for rejected files)'),
+    otherwise: Joi.string().valid(...allowedMimeTypes).description('MIME type detected by virus scanning')
+  }).label('detectedContentType'),
 
   contentLength: Joi.number()
     .integer()
@@ -66,6 +71,10 @@ const cdpStatusFileBaseSchema = Joi.object({
   hasError: Joi.boolean().label('hasError'),
 
   errorMessage: Joi.string().min(1).max(ERROR_MESSAGE_MAX_LENGTH).label('errorMessage'),
+
+  errorCode: Joi.string().min(1).max(100).description('Stable error code for localisation (e.g. FILE_TOO_LARGE, WRONG_TYPE)').label('errorCode'),
+
+  errorParams: Joi.object().description('Additional parameters for the error code (e.g. { maxFileSize: 10000000 })').label('errorParams'),
 
   checksumSha256: Joi.string()
     .pattern(base64Pattern)

--- a/test/integration/narrow/api/uploader/status.test.js
+++ b/test/integration/narrow/api/uploader/status.test.js
@@ -8,7 +8,7 @@ const { mockHttpClient } = vi.hoisted(() => ({ mockHttpClient: vi.fn() }))
 vi.mock('../../../../../src/http/client.js', () => ({
   httpClient: mockHttpClient,
   TimeoutError: class TimeoutError extends Error {
-    constructor(msg) { super(msg); this.name = 'TimeoutError' }
+    constructor (msg) { super(msg); this.name = 'TimeoutError' }
   },
   NetworkError: class NetworkError extends Error { },
   AbortError: class AbortError extends Error { }
@@ -259,6 +259,42 @@ describe('GET /api/v1/uploader/status/{uploadId} — successful responses', () =
     expect(file.hasError).toBe(true)
     expect(file.errorMessage).toBeDefined()
     expect(file.detectedContentType).toBeUndefined()
+  })
+
+  test('returns 200 with failure status and errorMessage when file is rejected for wrong MIME type', async () => {
+    const wrongTypeRejectedFile = {
+      fileId: 'c2d3e4f5-a6b7-4789-abcd-ef0123456789',
+      filename: 'test.zip',
+      contentType: 'application/zip',
+      fileStatus: 'rejected',
+      hasError: true,
+      errorCode: 'WRONG_TYPE',
+      errorMessage: 'The selected file type is not allowed'
+    }
+    const responseWithWrongType = {
+      uploadStatus: 'ready',
+      metadata: validMetadata,
+      form: { 'file-field': wrongTypeRejectedFile },
+      numberOfRejectedFiles: 1
+    }
+    mockHttpClient.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => responseWithWrongType
+    })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: `/api/v1/uploader/status/${validUploadId}`
+    })
+
+    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
+    expect(response.result.data.uploadStatus).toBe('failure')
+    const file = response.result.data.form['file-field']
+    expect(file.fileStatus).toBe('rejected')
+    expect(file.contentType).toBe('application/zip')
+    expect(file.errorMessage).toBe('The selected file type is not allowed')
+    expect(file.errorCode).toBe('WRONG_TYPE')
   })
 
   test('returns 200 with pending status for pending response with full metadata and empty form', async () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -5,6 +5,7 @@ process.env.CDP_UPLOADER_S3_BUCKET = process.env.CDP_UPLOADER_S3_BUCKET || 'test
 process.env.CDP_UPLOADER_S3_PATH = process.env.CDP_UPLOADER_S3_PATH || 'test/path'
 process.env.CDP_UPLOADER_CALLBACK_URL = process.env.CDP_UPLOADER_CALLBACK_URL || 'http://localhost:3000/callback'
 process.env.CDP_UPLOADER_MAX_FILE_SIZE = process.env.CDP_UPLOADER_MAX_FILE_SIZE || '10485760'
+process.env.CDP_UPLOADER_MIME_TYPES = process.env.CDP_UPLOADER_MIME_TYPES || 'image/png,image/jpeg,image/gif,image/tiff,application/pdf,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.ms-excel.sheet.macroEnabled.12,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-word.document.macroEnabled.12'
 process.env.MONGO_READ_PREFERENCE = process.env.MONGO_READ_PREFERENCE || 'primary'
 // Set the topic ARN used by tests to the expected value
 process.env.DOCUMENT_UPLOAD_EVENTS_TOPIC_ARN = 'arn:aws:sns:eu-west-2:000000000000:fcp_sfd_object_processor_events'

--- a/test/unit/api/v1/uploader/status/schema.test.js
+++ b/test/unit/api/v1/uploader/status/schema.test.js
@@ -1,5 +1,22 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import { constants as httpConstants } from 'node:http2'
+
+// Populate the MIME allow-list so `Joi.string().valid(...allowedMimeTypes)` is
+// an active constraint. Without this the config default is [] and valid() is
+// inert, which would let disallowed content types pass regardless of the schema.
+const { mockConfigGet } = vi.hoisted(() => ({
+  mockConfigGet: vi.fn().mockImplementation((key) => {
+    switch (key) {
+      case 'cdpUploaderMimeTypes': return ['application/pdf', 'image/jpeg', 'image/png']
+      case 'cdpUploaderDocumentTypes': return ['CS_Agreement_Evidence', 'CS_Application_Evidence']
+      default: return null
+    }
+  })
+}))
+
+vi.mock('../../../../../../src/config/index.js', () => ({
+  config: { get: mockConfigGet }
+}))
 
 import {
   uploaderStatusParamsSchema,
@@ -218,6 +235,100 @@ describe('cdpUploaderStatusResponseSchema', () => {
       }
       const { error } = cdpUploaderStatusResponseSchema.validate(payload)
       expect(error).toBeUndefined()
+    })
+
+    test('rejected file with contentType: application/zip (wrong type rejection) passes', () => {
+      const wrongTypeRejectedFile = {
+        fileId: 'a0b1c2d3-e4f5-4789-abcd-ef0123456789',
+        filename: 'test.zip',
+        contentType: 'application/zip',
+        fileStatus: 'rejected',
+        hasError: true,
+        errorMessage: 'The selected file type is not allowed'
+      }
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': wrongTypeRejectedFile },
+        numberOfRejectedFiles: 1
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeUndefined()
+    })
+
+    test('rejected file with disallowed detectedContentType passes', () => {
+      const wrongTypeRejectedFile = {
+        fileId: 'a0b1c2d3-e4f5-4789-abcd-ef0123456789',
+        filename: 'test.zip',
+        contentType: 'application/zip',
+        detectedContentType: 'application/zip',
+        fileStatus: 'rejected',
+        hasError: true,
+        errorMessage: 'The selected file type is not allowed'
+      }
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': wrongTypeRejectedFile },
+        numberOfRejectedFiles: 1
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeUndefined()
+    })
+
+    test('rejected file with errorCode passes', () => {
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': { ...rejectedFile, errorCode: 'WRONG_TYPE' } },
+        numberOfRejectedFiles: 1
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeUndefined()
+    })
+
+    test('rejected file with errorParams passes', () => {
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': { ...rejectedFile, errorCode: 'FILE_TOO_LARGE', errorParams: { maxFileSize: 10000000 } } },
+        numberOfRejectedFiles: 1
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeUndefined()
+    })
+
+    test('non-rejected (pending) file with disallowed contentType still fails', () => {
+      const pendingZipFile = {
+        fileId: 'a0b1c2d3-e4f5-4789-abcd-ef0123456789',
+        filename: 'test.zip',
+        contentType: 'application/zip',
+        fileStatus: 'pending'
+      }
+      const payload = {
+        uploadStatus: 'pending',
+        metadata: validMetadata,
+        form: { 'file-field': pendingZipFile }
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeDefined()
+      expect(error.message).toContain('contentType')
+    })
+
+    test('complete file with disallowed contentType still fails', () => {
+      const completeZipFile = {
+        ...completeFile,
+        contentType: 'application/zip'
+      }
+      const payload = {
+        uploadStatus: 'ready',
+        metadata: validMetadata,
+        form: { 'file-field': completeZipFile },
+        numberOfRejectedFiles: 0
+      }
+      const { error } = cdpUploaderStatusResponseSchema.validate(payload)
+      expect(error).toBeDefined()
+      expect(error.message).toContain('contentType')
     })
 
     test('rejected file with contentLength: 0 passes via status endpoint', () => {


### PR DESCRIPTION
# Description

The fix is to relax both fields in `cdpStatusFileBaseSchema` so that when `fileStatus` is `rejected`, any string value is accepted rather than only the allow-listed MIME types because we would not know why it's rejected ahead of time.

## Checklist

- [ ] has cloned repo locally
- [ ] has updated the ticket with version number
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity