### PR TITLE
FLS1-114#2: add atomic outbox message claiming

### DIFF
--- a/compose.qa.yaml
+++ b/compose.qa.yaml
@@ -1,0 +1,10 @@
+services:
+  fcp-sfd-object-processor:
+    container_name: !reset null
+    ports: !reset []
+
+  mongodb:
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./scripts/qa:/qa:ro

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,0 +1,105 @@
+# Outbox concurrency QA test
+
+> **Non-production only.** Do not run this tooling against a production database.
+
+This test creates related metadata and `PENDING` outbox records so multiple object-processor instances can compete for work. It verifies atomic claim ownership; it does not provide exactly-once delivery. The outbox remains at-least-once and downstream consumers must remain idempotent.
+
+## Prerequisites
+
+- `mongosh` with authorised read/write access to the object processor database.
+- Permission to insert, query and delete records in `uploadMetadata` and `outbox`.
+- For local testing, Docker with Compose v2.
+- For an environment test, an approved non-production environment with at least two object-processor instances.
+
+Obtain database access through the team's approved method. Supply the connection string to `mongosh` when running the script. Do not add credentials, connection strings or environment-specific configuration to this repository.
+
+## Configuration
+
+The script reads these optional global configuration values. Set them with `mongosh --eval` before executing the script:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OUTBOX_QA_RECORD_COUNT` | `250` | Number of metadata and outbox records to create. Use more than twice `MONGO_OUTBOX_QUERY_LIMIT`. |
+| `OUTBOX_QA_TEST_RUN_ID` | Generated | Unique identifier attached to every generated record. Must be at least eight characters. |
+| `OUTBOX_QA_MODE` | `insert` | Set to `cleanup` to remove one test run. |
+| `OUTBOX_QA_CONFIRM_CLEANUP` | None | Must equal `DELETE <test-run-id>` before cleanup is allowed. |
+
+The generated file IDs and correlation IDs are unique and remain stable throughout retries. Reusing an existing test-run identifier is rejected.
+
+## Run locally with two instances
+
+The QA Compose overlay removes the fixed application container name and host ports, allowing Compose to create multiple workers. MongoDB remains available to the host on port `27017`.
+
+Start the stack from the repository root:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml up --build --scale fcp-sfd-object-processor=2
+```
+
+Confirm that two workers are running:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml ps fcp-sfd-object-processor
+```
+
+In another terminal, run the read-only mounted script using `mongosh` from the MongoDB container:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml exec -T mongodb mongosh "mongodb://localhost:27017/fcp-sfd-object-processor?replicaSet=rs0" /qa/outbox-concurrency.mongosh.js
+```
+
+This does not require `mongosh` to be installed on the host.
+
+To use an explicit test-run identifier or record count:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml exec -T mongodb mongosh "mongodb://localhost:27017/fcp-sfd-object-processor?replicaSet=rs0" --eval 'globalThis.OUTBOX_QA_TEST_RUN_ID="outbox-qa-local-001"; globalThis.OUTBOX_QA_RECORD_COUNT=250' /qa/outbox-concurrency.mongosh.js
+```
+
+Inspect both workers' structured logs:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml logs fcp-sfd-object-processor
+```
+
+## Run in a non-production environment
+
+1. Record the deployed version, CPU, memory and current instance count.
+2. Deploy the implementation and use **Edit** in the CDP Portal to set the object processor to at least two instances.
+3. Confirm from deployment information and logs that two distinct instances are running.
+4. Obtain an authorised `mongosh` connection using the team's approved method.
+5. Set `OUTBOX_QA_RECORD_COUNT` to more than twice the environment's `MONGO_OUTBOX_QUERY_LIMIT`; use at least `250` when the limit is `100`.
+6. Run `scripts/qa/outbox-concurrency.mongosh.js` against the `fcp-sfd-object-processor` database and record the printed test-run identifier.
+
+The script does not require CDP Terminal, MongoDB Compass or any other specific execution environment. CDP Terminal may be used only if it provides the required `mongosh` access and permissions.
+
+## Inspect the result
+
+The script prints inspection queries containing the exact test-run identifier. Run them in the same database. Also inspect structured application logs for that test period.
+
+Verify that:
+
+- at least two distinct worker identifiers claim records from the test run;
+- no record has overlapping valid claim ownership;
+- non-expired claims are not taken by another worker;
+- finalisation is performed only by the current claim owner;
+- successfully published records reach `SENT`;
+- no record remains indefinitely in `PROCESSING`.
+
+If practical, stop or redeploy one instance after it claims records. After the lease expires, verify that another worker reclaims them and that the previous owner cannot finalise them.
+
+Compose scheduling does not guarantee that both local workers receive records. The default volume makes participation likely, but the worker IDs in the logs are the evidence. Repeat with a larger record count if only one worker participates.
+
+Capture the instance count, worker identifiers, test-run identifier, relevant structured logs and final MongoDB status counts as evidence.
+
+## Clean up
+
+Cleanup is restricted to records carrying one explicit, non-empty test-run identifier. Copy the exact identifier printed during insertion and provide the required confirmation.
+
+Local container example:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml exec -T mongodb mongosh "mongodb://localhost:27017/fcp-sfd-object-processor?replicaSet=rs0" --eval 'globalThis.OUTBOX_QA_MODE="cleanup"; globalThis.OUTBOX_QA_TEST_RUN_ID="outbox-qa-local-001"; globalThis.OUTBOX_QA_CONFIRM_CLEANUP="DELETE outbox-qa-local-001"' /qa/outbox-concurrency.mongosh.js
+```
+
+The script reports the number of deleted `outbox` and `uploadMetadata` records. Query both collections using the test-run identifier and confirm that no matching records remain. Restore the original environment instance count after testing.

--- a/scripts/qa/outbox-concurrency.mongosh.js
+++ b/scripts/qa/outbox-concurrency.mongosh.js
@@ -1,0 +1,131 @@
+/* global db, ObjectId, print */
+
+// NON-PRODUCTION QA TOOLING ONLY.
+// Connection details must be supplied to mongosh; this script contains none.
+
+const readConfiguration = (name) => {
+  const value = globalThis[name]
+  return typeof value === 'string' ? value.trim() : value
+}
+const defaultRecordCount = 250
+const recordCount = Number.parseInt(readConfiguration('OUTBOX_QA_RECORD_COUNT') ?? `${defaultRecordCount}`, 10)
+const requestedTestRunId = readConfiguration('OUTBOX_QA_TEST_RUN_ID')
+const configuredMode = readConfiguration('OUTBOX_QA_MODE')
+const mode = typeof configuredMode === 'string' ? configuredMode.toLowerCase() : 'insert'
+
+const generateUuid = () => {
+  const first = new ObjectId().toString()
+  const second = new ObjectId().toString()
+
+  return `${first.slice(0, 8)}-${first.slice(8, 12)}-4${first.slice(13, 16)}-8${first.slice(17, 20)}-${first.slice(20, 24)}${second.slice(0, 8)}`
+}
+
+const generatedTestRunId = `outbox-qa-${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${new ObjectId()}`
+const testRunId = requestedTestRunId || generatedTestRunId
+
+const assertSafeTestRunId = () => {
+  if (!testRunId || testRunId.length < 8) {
+    throw new Error('OUTBOX_QA_TEST_RUN_ID must contain at least 8 characters')
+  }
+}
+
+const printInspectionQueries = () => {
+  print('Inspection queries:')
+  print(`db.outbox.aggregate([{ $match: { qaTestRunId: "${testRunId}" } }, { $group: { _id: "$status", count: { $sum: 1 } } }, { $sort: { _id: 1 } }])`)
+  print(`db.outbox.find({ qaTestRunId: "${testRunId}" }, { status: 1, attempts: 1, claimedBy: 1, claimedAt: 1, claimedUntil: 1, lastAttemptedAt: 1 }).sort({ createdAt: 1 })`)
+  print(`db.uploadMetadata.countDocuments({ qaTestRunId: "${testRunId}" })`)
+}
+
+const cleanUp = () => {
+  assertSafeTestRunId()
+
+  const expectedConfirmation = `DELETE ${testRunId}`
+  if (readConfiguration('OUTBOX_QA_CONFIRM_CLEANUP') !== expectedConfirmation) {
+    throw new Error(`Cleanup refused. Set OUTBOX_QA_CONFIRM_CLEANUP exactly to: ${expectedConfirmation}`)
+  }
+
+  const outboxResult = db.outbox.deleteMany({ qaTestRunId: testRunId })
+  const metadataResult = db.uploadMetadata.deleteMany({ qaTestRunId: testRunId })
+
+  print(`Cleaned QA test run: ${testRunId}`)
+  print(`Deleted outbox records: ${outboxResult.deletedCount}`)
+  print(`Deleted metadata records: ${metadataResult.deletedCount}`)
+}
+
+const buildMetadata = (index, fileId, correlationId) => {
+  const sequence = String(index + 1).padStart(6, '0')
+
+  return {
+    qaTestRunId: testRunId,
+    metadata: {
+      sbi: Number(`105${sequence}`),
+      crn: Number(`1050${sequence}`),
+      frn: Number(`1102${sequence}`),
+      submissionId: `${testRunId}-${sequence}`,
+      uosr: `${testRunId}-${sequence}`,
+      type: 'CS_Agreement_Evidence',
+      reference: `Outbox concurrency QA ${testRunId} record ${index + 1}`,
+      service: 'SFD-QA'
+    },
+    file: {
+      fileId,
+      filename: `outbox-concurrency-${testRunId}-${sequence}.pdf`,
+      contentType: 'application/pdf',
+      fileStatus: 'complete'
+    },
+    s3: {
+      key: `qa/${testRunId}/${fileId}.pdf`,
+      bucket: 'qa-placeholder-not-for-download'
+    },
+    messaging: {
+      publishedAt: null,
+      correlationId
+    },
+    raw: {
+      uploadStatus: 'complete',
+      numberOfRejectedFiles: 0
+    }
+  }
+}
+
+const insertTestData = () => {
+  assertSafeTestRunId()
+
+  if (!Number.isSafeInteger(recordCount) || recordCount < 1) {
+    throw new Error('OUTBOX_QA_RECORD_COUNT must be a positive integer')
+  }
+
+  if (db.outbox.countDocuments({ qaTestRunId: testRunId }) > 0 ||
+      db.uploadMetadata.countDocuments({ qaTestRunId: testRunId }) > 0) {
+    throw new Error(`Test-run identifier already exists: ${testRunId}`)
+  }
+
+  const metadataRecords = Array.from({ length: recordCount }, (_, index) => {
+    return buildMetadata(index, generateUuid(), generateUuid())
+  })
+  const metadataResult = db.uploadMetadata.insertMany(metadataRecords)
+  const insertedMetadataIds = Object.values(metadataResult.insertedIds)
+  const outboxRecords = insertedMetadataIds.map((messageId, index) => ({
+    qaTestRunId: testRunId,
+    messageId,
+    payload: metadataRecords[index],
+    status: 'PENDING',
+    attempts: 0,
+    createdAt: new Date()
+  }))
+  const outboxResult = db.outbox.insertMany(outboxRecords)
+
+  print('NON-PRODUCTION QA TOOLING')
+  print(`Test-run identifier: ${testRunId}`)
+  print(`Inserted metadata records: ${Object.keys(metadataResult.insertedIds).length}`)
+  print(`Inserted outbox records: ${Object.keys(outboxResult.insertedIds).length}`)
+  printInspectionQueries()
+}
+
+if (mode === 'cleanup') {
+  cleanUp()
+} else if (mode === 'insert') {
+  insertTestData()
+} else {
+  throw new Error('OUTBOX_QA_MODE must be either insert or cleanup')
+}

--- a/src/messaging/outbound/crm/doc-upload/publish-pending-messages.js
+++ b/src/messaging/outbound/crm/doc-upload/publish-pending-messages.js
@@ -1,83 +1,185 @@
 import { createLogger } from '../../../../logging/logger.js'
 import { config } from '../../../../config/index.js'
-import { getProcessableOutboxEntries, bulkUpdateDeliveryStatus, logTerminalFailuresIfAny } from '../../../../repos/outbox.js'
+import {
+  claimProcessableOutboxEntries,
+  finalizeClaimedOutboxEntries,
+  logTerminalFailuresIfAny
+} from '../../../../repos/outbox.js'
 import { bulkUpdatePublishedAtDate } from '../../../../repos/metadata.js'
 import { publishDocumentUploadMessageBatch } from './publish-document-upload-message-batch.js'
-import { SENT, FAILED, BATCH_SIZE } from '../../../../constants/outbox.js'
+import { PENDING, SENT, FAILED, BATCH_SIZE } from '../../../../constants/outbox.js'
 import { client } from '../../../../data/db.js'
+import { outboxWorkerId } from '../../outbox-worker-id.js'
 
 const logger = createLogger()
+const publishFailureMessage = 'Failed to send message'
+
+const getEntryId = (entry) => entry?.payload?.file?.fileId || entry?.messageId
+
+const mapPublishResultsToEntries = (batch, results) => {
+  const entriesById = new Map(batch.map(entry => [getEntryId(entry), entry]))
+
+  return results.flatMap(result => {
+    const entry = entriesById.get(result.Id)
+    if (!entry) {
+      logger.warn({
+        event: {
+          type: 'outbox_publish_result_unmatched',
+          outcome: 'failure',
+          entryId: result.Id,
+          reason: 'publish_result_did_not_match_claimed_entry'
+        }
+      }, 'SNS publish result did not match a claimed outbox entry')
+      return []
+    }
+    return [entry]
+  })
+}
+
+const finalizeEntries = async (session, entries, deliveryStatus, error = null) => {
+  const finalized = []
+  const rejected = []
+
+  for (const entry of entries) {
+    const result = await finalizeClaimedOutboxEntries(
+      session,
+      [entry._id],
+      outboxWorkerId,
+      deliveryStatus,
+      error
+    )
+
+    if (result.matchedCount === 1) {
+      finalized.push(entry)
+    } else {
+      rejected.push(entry)
+    }
+  }
+
+  return { finalized, rejected }
+}
+
+const logRejectedFinalizations = (entries) => {
+  entries.forEach(entry => {
+    logger.warn({
+      event: {
+        type: 'outbox_finalization_rejected',
+        reference: entry._id?.toString(),
+        outcome: 'failure',
+        entryId: getEntryId(entry),
+        claimedBy: outboxWorkerId,
+        reason: 'claim_expired_or_ownership_lost'
+      }
+    }, 'Outbox entry could not be finalized by this worker')
+  })
+}
+
+const logFinalizations = (entries, status) => {
+  entries.forEach(entry => {
+    logger.info({
+      event: {
+        type: 'outbox_finalized',
+        reference: entry._id?.toString(),
+        outcome: status === SENT ? 'success' : 'failure',
+        entryId: getEntryId(entry),
+        claimedBy: outboxWorkerId,
+        status,
+        attempts: (entry.attempts || 0) + 1
+      }
+    }, `Outbox entry finalized as ${status}`)
+  })
+}
+
+const logTerminalFailures = (entries, failedResults) => {
+  entries.forEach(entry => {
+    const entryId = getEntryId(entry) || null
+    const failedInfo = failedResults.find(failure => failure.Id === entryId) || {}
+    const reason = failedInfo.Message || failedInfo.Code || 'failed_to_publish'
+
+    logger.error({
+      event: {
+        type: 'outbox_terminal_failure_imminent',
+        reference: entry._id?.toString(),
+        outcome: 'failure',
+        entryId,
+        attempts: (entry.attempts || 0) + 1,
+        reason
+      }
+    }, 'Outbox entry will reach FAILED after this attempt')
+  })
+}
 
 const publishPendingMessages = async () => {
   const session = client.startSession()
 
   try {
-    const pendingMessages = await getProcessableOutboxEntries()
+    const pendingMessages = await claimProcessableOutboxEntries(outboxWorkerId)
 
     if (!pendingMessages.length) {
       logger.info('No pending outbox messages to process.')
       return
     }
 
+    pendingMessages.forEach(entry => {
+      logger.info({
+        event: {
+          type: 'outbox_claimed',
+          reference: entry._id?.toString(),
+          outcome: 'success',
+          entryId: getEntryId(entry),
+          claimedBy: entry.claimedBy,
+          claimedAt: entry.claimedAt,
+          claimedUntil: entry.claimedUntil
+        }
+      }, 'Outbox entry claimed for processing')
+    })
+
     logger.info(`Processing ${pendingMessages.length} outbox message(s).`)
 
     for (let i = 0; i < pendingMessages.length; i += BATCH_SIZE) {
       const batch = pendingMessages.slice(i, i + BATCH_SIZE)
-
       const { Successful, Failed } = await publishDocumentUploadMessageBatch(batch)
-      const failedIds = Failed.map(f => f.Id)
-
-      // Cross-reference failed IDs against the batch to detect entries
-      // that will reach terminal FAILED state after this attempt and log
-      // a structured error for them.
-      if (Failed.length > 0) {
-        const maxAttempts = config.get('messaging.outboxMaxAttempts')
-
-        const imminentTerminal = batch.filter(entry => {
-          const entryId = entry?.payload?.file?.fileId || entry?.messageId
-          return failedIds.includes(entryId) && ((entry.attempts || 0) + 1) >= maxAttempts
-        })
-
-        imminentTerminal.forEach(entry => {
-          const entryId = entry?.payload?.file?.fileId || entry?.messageId || null
-          const attempts = (entry.attempts || 0) + 1
-          const failedInfo = Failed.find(f => f.Id === entryId) || {}
-          const reason = failedInfo.Message || failedInfo.Code || 'failed_to_publish'
-
-          logger.error({
-            event: {
-              type: 'outbox_terminal_failure_imminent',
-              reference: entry._id?.toString(),
-              outcome: 'failure',
-              entryId,
-              attempts,
-              reason
-            }
-          }, 'Outbox entry will reach FAILED after this attempt')
-        })
-      }
+      const successfulEntries = mapPublishResultsToEntries(batch, Successful)
+      const failedEntries = mapPublishResultsToEntries(batch, Failed)
+      let finalizedSuccessful = []
+      let finalizedFailed = []
+      let rejected = []
 
       await session.withTransaction(async () => {
-        if (Successful.length > 0) {
-          const messageIds = Successful.map(message => message.Id)
-          await bulkUpdateDeliveryStatus(session, messageIds, SENT)
-          await bulkUpdatePublishedAtDate(session, messageIds)
-        }
+        const successfulResult = await finalizeEntries(session, successfulEntries, SENT)
+        const failedResult = await finalizeEntries(session, failedEntries, FAILED, publishFailureMessage)
 
-        if (Failed.length > 0) {
-          await bulkUpdateDeliveryStatus(session, failedIds, FAILED, 'Failed to send message')
+        finalizedSuccessful = successfulResult.finalized
+        finalizedFailed = failedResult.finalized
+        rejected = [...successfulResult.rejected, ...failedResult.rejected]
+
+        if (finalizedSuccessful.length > 0) {
+          await bulkUpdatePublishedAtDate(session, finalizedSuccessful.map(getEntryId))
         }
       })
 
-      // Transaction committed — emit audit events for terminal failures outside the transaction
-      // boundary to prevent duplicate events if the driver retries the transaction callback.
-      if (Failed.length > 0) {
-        const collection = config.get('mongo.collections.outbox')
+      logFinalizations(finalizedSuccessful, SENT)
+      logRejectedFinalizations(rejected)
+
+      if (finalizedFailed.length > 0) {
         const maxAttempts = config.get('messaging.outboxMaxAttempts')
-        await logTerminalFailuresIfAny(collection, failedIds, maxAttempts, null, 'Failed to send message')
+        const terminalEntries = finalizedFailed.filter(entry => ((entry.attempts || 0) + 1) >= maxAttempts)
+        const retryableEntries = finalizedFailed.filter(entry => ((entry.attempts || 0) + 1) < maxAttempts)
+
+        logFinalizations(retryableEntries, PENDING)
+        logFinalizations(terminalEntries, FAILED)
+        logTerminalFailures(terminalEntries, Failed)
+
+        await logTerminalFailuresIfAny(
+          config.get('mongo.collections.outbox'),
+          finalizedFailed.map(getEntryId),
+          maxAttempts,
+          null,
+          publishFailureMessage
+        )
       }
 
-      logger.info(`Outbox processing complete. Total: ${Successful.length} sent, ${Failed.length} failed`)
+      logger.info(`Outbox processing complete. Total: ${finalizedSuccessful.length} sent, ${finalizedFailed.length} failed, ${rejected.length} rejected`)
     }
   } catch (error) {
     logger.error(error, 'Error publishing pending outbox messages')

--- a/src/repos/outbox.js
+++ b/src/repos/outbox.js
@@ -9,44 +9,6 @@ const logger = createLogger()
 const outboxCollection = 'mongo.collections.outbox'
 const outboxMaxAttemptsConfig = 'messaging.outboxMaxAttempts'
 
-const buildFailurePipeline = (maxAttempts, errorMessage) => ([
-  {
-    $set: {
-      lastAttemptedAt: new Date(),
-      ...(errorMessage && { error: errorMessage })
-    }
-  },
-  {
-    $set: {
-      attempts: { $add: ['$attempts', 1] }
-    }
-  },
-  {
-    $set: {
-      status: {
-        // `attempts` has already been incremented in the previous stage,
-        // compare the updated value against `maxAttempts` to avoid double-increment.
-        $cond: [{ $gte: ['$attempts', maxAttempts] }, FAILED, PENDING]
-      }
-    }
-  }
-])
-
-const performSentUpdate = (collectionName, statusValue, filterObj, sess) => {
-  const updateDoc = {
-    $set: {
-      status: statusValue,
-      lastAttemptedAt: new Date()
-    },
-    $inc: { attempts: 1 }
-  }
-  return db.collection(collectionName).updateMany(filterObj, updateDoc, { session: sess })
-}
-
-const performFailureUpdate = (collectionName, filterObj, pipeline, sess) => {
-  return db.collection(collectionName).updateMany(filterObj, pipeline, { session: sess })
-}
-
 const logTerminalFailuresIfAny = async (collectionName, fileIdsArr, maxAttemptsVal, sess, errMsg) => {
   const terminalFilter = {
     'payload.file.fileId': { $in: fileIdsArr },
@@ -128,19 +90,6 @@ const createOutboxEntries = async (ids, documents, session) => {
     throw new Error('Failed to insert outbox entries')
   }
   return insertedIds
-}
-
-const getProcessableOutboxEntries = async () => {
-  const collection = config.get(outboxCollection)
-  const queryLimit = config.get('mongo.outboxQueryLimit')
-  const maxAttempts = config.get(outboxMaxAttemptsConfig)
-
-  const processableEntries = await db.collection(collection)
-    .find({ status: { $in: [PENDING, FAILED] }, attempts: { $lt: maxAttempts } })
-    .limit(queryLimit)
-    .toArray()
-
-  return processableEntries
 }
 
 const claimProcessableOutboxEntries = async (instanceId, now = new Date()) => {
@@ -274,42 +223,9 @@ const finalizeClaimedOutboxEntries = async (
   return updateResult
 }
 
-const bulkUpdateDeliveryStatus = async (session, fileIds, status, error = null) => {
-  const collection = config.get(outboxCollection)
-  const maxAttempts = config.get(outboxMaxAttemptsConfig)
-
-  const filter = { 'payload.file.fileId': { $in: fileIds } }
-
-  let updateResult
-
-  // Note: `status` signals the outcome of this delivery attempt as passed
-  // by the caller. It does not necessarily represent the final persisted
-  // status for the outbox entry — after the update the entry may remain
-  // `PENDING` if `attempts` (after increment) are still below `maxAttempts`.
-
-  if (status === SENT) {
-    // On successful delivery: set status, lastAttemptedAt and increment attempts
-    updateResult = await performSentUpdate(collection, status, filter, session)
-  } else {
-    // On failure: increment attempts, set lastAttemptedAt and error; only mark FINAL FAILED
-    // when attempts after increment reach or exceed maxAttempts. Use update pipeline so we can
-    // compute the new attempts value and set status conditionally.
-    const pipeline = buildFailurePipeline(maxAttempts, error)
-    updateResult = await performFailureUpdate(collection, filter, pipeline, session)
-  }
-
-  if (!updateResult.acknowledged) {
-    throw new Error('Failed to update outbox entries')
-  }
-
-  return updateResult
-}
-
 export {
   createOutboxEntries,
-  getProcessableOutboxEntries,
   claimProcessableOutboxEntries,
   finalizeClaimedOutboxEntries,
-  bulkUpdateDeliveryStatus,
   logTerminalFailuresIfAny
 }

--- a/src/repos/outbox.js
+++ b/src/repos/outbox.js
@@ -1,5 +1,5 @@
 import { config } from '../config/index.js'
-import { PENDING, FAILED, SENT } from '../constants/outbox.js'
+import { PENDING, PROCESSING, FAILED, SENT } from '../constants/outbox.js'
 import { db } from '../data/db.js'
 import { createLogger } from '../logging/logger.js'
 import { sendAuditEvent } from '../messaging/outbound/audit/send-audit-event.js'
@@ -142,6 +142,137 @@ const getProcessableOutboxEntries = async () => {
   return processableEntries
 }
 
+const claimProcessableOutboxEntries = async (instanceId, now = new Date()) => {
+  const collection = config.get(outboxCollection)
+  const queryLimit = config.get('mongo.outboxQueryLimit')
+  const maxAttempts = config.get('messaging.outboxMaxAttempts')
+  const leaseTimeoutMs = config.get('messaging.outboxClaimLeaseMs')
+  const claimedUntil = new Date(now.getTime() + leaseTimeoutMs)
+  const claimedEntries = []
+
+  const filter = {
+    attempts: { $lt: maxAttempts },
+    $or: [
+      { status: PENDING },
+      { status: PROCESSING, claimedUntil: { $lt: now } }
+    ]
+  }
+
+  const update = {
+    $set: {
+      status: PROCESSING,
+      claimedAt: now,
+      claimedUntil,
+      claimedBy: instanceId
+    }
+  }
+
+  for (let index = 0; index < queryLimit; index++) {
+    const entry = await db.collection(collection).findOneAndUpdate(filter, update, {
+      sort: { createdAt: 1 },
+      returnDocument: 'before'
+    })
+
+    if (!entry) {
+      break
+    }
+
+    if (entry.status === PROCESSING) {
+      logger.warn({
+        event: {
+          type: 'outbox_claim_reclaimed',
+          reference: entry._id?.toString(),
+          previousClaimedBy: entry.claimedBy,
+          previousClaimedUntil: entry.claimedUntil,
+          claimedBy: instanceId,
+          claimedUntil
+        }
+      }, 'Reclaimed expired outbox claim')
+    }
+
+    claimedEntries.push({
+      ...entry,
+      status: PROCESSING,
+      claimedAt: now,
+      claimedUntil,
+      claimedBy: instanceId
+    })
+  }
+
+  return claimedEntries
+}
+
+const buildClaimedFailurePipeline = (maxAttempts, error, now) => ([
+  {
+    $set: {
+      attempts: { $add: [{ $ifNull: ['$attempts', 0] }, 1] },
+      lastAttemptedAt: now,
+      ...(error && { error })
+    }
+  },
+  {
+    $set: {
+      status: {
+        $cond: [{ $gte: ['$attempts', maxAttempts] }, FAILED, PENDING]
+      }
+    }
+  },
+  {
+    $unset: ['claimedAt', 'claimedUntil', 'claimedBy']
+  }
+])
+
+const finalizeClaimedOutboxEntries = async (
+  session,
+  entryIds,
+  instanceId,
+  deliveryStatus,
+  error = null,
+  now = new Date()
+) => {
+  const collection = config.get(outboxCollection)
+  const maxAttempts = config.get('messaging.outboxMaxAttempts')
+  const filter = {
+    _id: { $in: entryIds },
+    status: PROCESSING,
+    claimedBy: instanceId,
+    claimedUntil: { $gt: now }
+  }
+  const options = session ? { session } : {}
+
+  let updateResult
+
+  if (deliveryStatus === SENT) {
+    updateResult = await db.collection(collection).updateMany(filter, {
+      $set: {
+        status: SENT,
+        lastAttemptedAt: now
+      },
+      $inc: { attempts: 1 },
+      $unset: {
+        claimedAt: '',
+        claimedUntil: '',
+        claimedBy: '',
+        error: ''
+      }
+    }, options)
+  } else if (deliveryStatus === FAILED) {
+    updateResult = await db.collection(collection).updateMany(
+      filter,
+      buildClaimedFailurePipeline(maxAttempts, error, now),
+      options
+    )
+  } else {
+    throw new Error(`Unsupported outbox delivery status: ${deliveryStatus}`)
+  }
+
+  if (!updateResult.acknowledged) {
+    throw new Error('Failed to finalize claimed outbox entries')
+  }
+
+  return updateResult
+}
+
 const bulkUpdateDeliveryStatus = async (session, fileIds, status, error = null) => {
   const collection = config.get(outboxCollection)
   const maxAttempts = config.get('messaging.outboxMaxAttempts')
@@ -176,6 +307,8 @@ const bulkUpdateDeliveryStatus = async (session, fileIds, status, error = null) 
 export {
   createOutboxEntries,
   getProcessableOutboxEntries,
+  claimProcessableOutboxEntries,
+  finalizeClaimedOutboxEntries,
   bulkUpdateDeliveryStatus,
   logTerminalFailuresIfAny
 }

--- a/src/repos/outbox.js
+++ b/src/repos/outbox.js
@@ -7,6 +7,7 @@ import { sendAuditEvent } from '../messaging/outbound/audit/send-audit-event.js'
 const logger = createLogger()
 
 const outboxCollection = 'mongo.collections.outbox'
+const outboxMaxAttemptsConfig = 'messaging.outboxMaxAttempts'
 
 const buildFailurePipeline = (maxAttempts, errorMessage) => ([
   {
@@ -132,7 +133,7 @@ const createOutboxEntries = async (ids, documents, session) => {
 const getProcessableOutboxEntries = async () => {
   const collection = config.get(outboxCollection)
   const queryLimit = config.get('mongo.outboxQueryLimit')
-  const maxAttempts = config.get('messaging.outboxMaxAttempts')
+  const maxAttempts = config.get(outboxMaxAttemptsConfig)
 
   const processableEntries = await db.collection(collection)
     .find({ status: { $in: [PENDING, FAILED] }, attempts: { $lt: maxAttempts } })
@@ -145,7 +146,7 @@ const getProcessableOutboxEntries = async () => {
 const claimProcessableOutboxEntries = async (instanceId, now = new Date()) => {
   const collection = config.get(outboxCollection)
   const queryLimit = config.get('mongo.outboxQueryLimit')
-  const maxAttempts = config.get('messaging.outboxMaxAttempts')
+  const maxAttempts = config.get(outboxMaxAttemptsConfig)
   const leaseTimeoutMs = config.get('messaging.outboxClaimLeaseMs')
   const claimedUntil = new Date(now.getTime() + leaseTimeoutMs)
   const claimedEntries = []
@@ -231,7 +232,7 @@ const finalizeClaimedOutboxEntries = async (
   now = new Date()
 ) => {
   const collection = config.get(outboxCollection)
-  const maxAttempts = config.get('messaging.outboxMaxAttempts')
+  const maxAttempts = config.get(outboxMaxAttemptsConfig)
   const filter = {
     _id: { $in: entryIds },
     status: PROCESSING,
@@ -275,7 +276,7 @@ const finalizeClaimedOutboxEntries = async (
 
 const bulkUpdateDeliveryStatus = async (session, fileIds, status, error = null) => {
   const collection = config.get(outboxCollection)
-  const maxAttempts = config.get('messaging.outboxMaxAttempts')
+  const maxAttempts = config.get(outboxMaxAttemptsConfig)
 
   const filter = { 'payload.file.fileId': { $in: fileIds } }
 

--- a/test/integration/narrow/messaging/start-outbox.test.js
+++ b/test/integration/narrow/messaging/start-outbox.test.js
@@ -253,8 +253,8 @@ describe('Outbox message processing', () => {
     expect(publishBatch).toHaveBeenCalledTimes(1)
   })
 
-  test('should retrieve and retry FAILED messages alongside PENDING messages', async () => {
-    // Arrange: Create mix of PENDING and FAILED entries
+  test('should process PENDING messages without retrying terminal FAILED messages', async () => {
+    // Arrange: Create a terminal FAILED entry alongside a PENDING entry
     const metadataId1 = ObjectId.createFromHexString('507f1f77bcf86cd799439015')
     const metadataId2 = ObjectId.createFromHexString('507f1f77bcf86cd799439016')
 
@@ -307,32 +307,33 @@ describe('Outbox message processing', () => {
     const insertResult = await db.collection(outboxCollection).insertMany(testMessages)
     const insertedIds = Object.values(insertResult.insertedIds)
 
-    // Mock SNS publishBatch to return successful response
+    // Mock SNS publishBatch to return a successful response for the PENDING entry only
     publishBatch.mockResolvedValue({
-      Successful: insertedIds.map((id, index) => ({
-        Id: testMessages[index].payload.file.fileId,
-        MessageId: `sns-message-${index}`,
-        SequenceNumber: String(index)
-      })),
+      Successful: [{
+        Id: testMessages[1].payload.file.fileId,
+        MessageId: 'sns-message-pending',
+        SequenceNumber: '1'
+      }],
       Failed: []
     })
 
     // Act: Run publishPendingMessages
     await publishPendingMessages()
 
-    // Assert: All PENDING and FAILED messages should be processed
+    // Assert: FAILED remains terminal and PENDING is processed
     const updatedMessages = await db.collection(outboxCollection)
       .find({ _id: { $in: insertedIds } })
       .toArray()
 
     expect(updatedMessages).toHaveLength(2)
-    expect(updatedMessages[0].attempts).toBe(2)
-    expect(updatedMessages[1].attempts).toBe(1)
-
-    updatedMessages.forEach(msg => {
-      expect(msg.status).toBe(SENT)
-      expect(msg.lastAttemptedAt).toBeInstanceOf(Date)
-    })
+    const failedMessage = updatedMessages.find(message => message._id.equals(insertedIds[0]))
+    const sentMessage = updatedMessages.find(message => message._id.equals(insertedIds[1]))
+    expect(failedMessage.status).toBe(FAILED)
+    expect(failedMessage.attempts).toBe(1)
+    expect(failedMessage.lastAttemptedAt).toBeUndefined()
+    expect(sentMessage.status).toBe(SENT)
+    expect(sentMessage.attempts).toBe(1)
+    expect(sentMessage.lastAttemptedAt).toBeInstanceOf(Date)
 
     // Assert: Verify metadata entries have publishedAt updated
     const updatedMetadata = await db.collection(metadataCollection)
@@ -340,10 +341,8 @@ describe('Outbox message processing', () => {
       .toArray()
 
     expect(updatedMetadata).toHaveLength(2)
-    updatedMetadata.forEach(doc => {
-      expect(doc.messaging.publishedAt).toBeInstanceOf(Date)
-      expect(doc.messaging.publishedAt).not.toBeNull()
-    })
+    expect(updatedMetadata.find(doc => doc._id.equals(metadataId1)).messaging.publishedAt).toBeNull()
+    expect(updatedMetadata.find(doc => doc._id.equals(metadataId2)).messaging.publishedAt).toBeInstanceOf(Date)
 
     // Verify publishBatch was called
     expect(publishBatch).toHaveBeenCalledTimes(1)
@@ -463,12 +462,12 @@ describe('Outbox message processing', () => {
     expect(publishBatch).toHaveBeenCalledTimes(1)
   })
 
-  test('should respect query limit when retrieving PENDING and FAILED messages combined', async () => {
+  test('should respect query limit while excluding terminal FAILED messages', async () => {
     // Arrange: Set query limit to 3
     const originalQueryLimit = config.get('mongo.outboxQueryLimit')
     config.set('mongo.outboxQueryLimit', 3)
 
-    // Create metadata and outbox entries - 3 PENDING + 3 FAILED = 6 total
+    // Create metadata and outbox entries - 3 PENDING + 3 terminal FAILED
     const metadataIds = [
       ObjectId.createFromHexString('507f1f77bcf86cd799439018'),
       ObjectId.createFromHexString('507f1f77bcf86cd799439019'),

--- a/test/integration/narrow/repos/outbox-claims.test.js
+++ b/test/integration/narrow/repos/outbox-claims.test.js
@@ -1,0 +1,198 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { config } from '../../../../src/config/index.js'
+import { db } from '../../../../src/data/db.js'
+import {
+  claimProcessableOutboxEntries,
+  finalizeClaimedOutboxEntries
+} from '../../../../src/repos/outbox.js'
+import { FAILED, PENDING, PROCESSING, SENT } from '../../../../src/constants/outbox.js'
+
+const originalCollectionName = config.get('mongo.collections.outbox')
+const collectionName = `${originalCollectionName}-claims-integration`
+const testRunPrefix = 'outbox-claims-'
+const originalConfig = {}
+
+const buildEntry = (testRunId, overrides = {}) => ({
+  testRunId,
+  messageId: randomUUID(),
+  payload: {
+    file: { fileId: randomUUID() },
+    messaging: { correlationId: randomUUID() }
+  },
+  status: PENDING,
+  attempts: 0,
+  createdAt: new Date(),
+  ...overrides
+})
+
+beforeAll(() => {
+  config.set('mongo.collections.outbox', collectionName)
+  originalConfig.queryLimit = config.get('mongo.outboxQueryLimit')
+  originalConfig.maxAttempts = config.get('messaging.outboxMaxAttempts')
+  originalConfig.claimLeaseMs = config.get('messaging.outboxClaimLeaseMs')
+})
+
+beforeEach(async () => {
+  config.set('mongo.outboxQueryLimit', 10)
+  config.set('messaging.outboxMaxAttempts', 3)
+  config.set('messaging.outboxClaimLeaseMs', 60000)
+  await db.collection(collectionName).deleteMany({ testRunId: { $regex: `^${testRunPrefix}` } })
+})
+
+afterEach(async () => {
+  await db.collection(collectionName).deleteMany({ testRunId: { $regex: `^${testRunPrefix}` } })
+})
+
+afterAll(async () => {
+  await db.collection(collectionName).deleteMany({})
+  config.set('mongo.collections.outbox', originalCollectionName)
+  config.set('mongo.outboxQueryLimit', originalConfig.queryLimit)
+  config.set('messaging.outboxMaxAttempts', originalConfig.maxAttempts)
+  config.set('messaging.outboxClaimLeaseMs', originalConfig.claimLeaseMs)
+})
+
+describe('outbox claim repository concurrency', () => {
+  test('concurrent workers claim non-overlapping entry sets', async () => {
+    const testRunId = `${testRunPrefix}${randomUUID()}`
+    await db.collection(collectionName).insertMany(
+      Array.from({ length: 20 }, (_, index) => buildEntry(testRunId, {
+        createdAt: new Date(Date.UTC(2026, 7, 7, 10, 0, index))
+      }))
+    )
+
+    const [workerOneEntries, workerTwoEntries] = await Promise.all([
+      claimProcessableOutboxEntries('worker-1'),
+      claimProcessableOutboxEntries('worker-2')
+    ])
+
+    const workerOneIds = new Set(workerOneEntries.map(entry => entry._id.toString()))
+    const workerTwoIds = new Set(workerTwoEntries.map(entry => entry._id.toString()))
+    const overlap = [...workerOneIds].filter(id => workerTwoIds.has(id))
+
+    expect(workerOneEntries).toHaveLength(10)
+    expect(workerTwoEntries).toHaveLength(10)
+    expect(overlap).toEqual([])
+    expect(new Set([...workerOneIds, ...workerTwoIds]).size).toBe(20)
+  })
+
+  test('does not claim active processing or terminal failed entries', async () => {
+    const testRunId = `${testRunPrefix}${randomUUID()}`
+    const now = new Date('2026-08-07T10:00:00.000Z')
+    await db.collection(collectionName).insertMany([
+      buildEntry(testRunId, {
+        status: PROCESSING,
+        claimedBy: 'worker-1',
+        claimedAt: new Date('2026-08-07T09:59:00.000Z'),
+        claimedUntil: new Date('2026-08-07T10:01:00.000Z')
+      }),
+      buildEntry(testRunId, { status: FAILED, attempts: 3 })
+    ])
+
+    const claimed = await claimProcessableOutboxEntries('worker-2', now)
+
+    expect(claimed).toEqual([])
+  })
+
+  test('reclaims an expired entry and prevents the previous owner finalizing it', async () => {
+    const testRunId = `${testRunPrefix}${randomUUID()}`
+    const reclaimTime = new Date('2026-08-07T10:00:00.000Z')
+    const { insertedId } = await db.collection(collectionName).insertOne(buildEntry(testRunId, {
+      status: PROCESSING,
+      claimedBy: 'worker-old',
+      claimedAt: new Date('2026-08-07T09:50:00.000Z'),
+      claimedUntil: new Date('2026-08-07T09:55:00.000Z')
+    }))
+
+    config.set('mongo.outboxQueryLimit', 1)
+    const reclaimed = await claimProcessableOutboxEntries('worker-new', reclaimTime)
+    const staleResult = await finalizeClaimedOutboxEntries(
+      null,
+      [insertedId],
+      'worker-old',
+      SENT,
+      null,
+      new Date('2026-08-07T10:00:01.000Z')
+    )
+    const ownerResult = await finalizeClaimedOutboxEntries(
+      null,
+      [insertedId],
+      'worker-new',
+      SENT,
+      null,
+      new Date('2026-08-07T10:00:01.000Z')
+    )
+
+    expect(reclaimed).toHaveLength(1)
+    expect(reclaimed[0]).toMatchObject({ _id: insertedId, claimedBy: 'worker-new', status: PROCESSING })
+    expect(staleResult.matchedCount).toBe(0)
+    expect(ownerResult.matchedCount).toBe(1)
+  })
+
+  test('does not allow an owner to finalize its own expired claim', async () => {
+    const testRunId = `${testRunPrefix}${randomUUID()}`
+    const { insertedId } = await db.collection(collectionName).insertOne(buildEntry(testRunId, {
+      status: PROCESSING,
+      claimedBy: 'worker-1',
+      claimedAt: new Date('2026-08-07T09:50:00.000Z'),
+      claimedUntil: new Date('2026-08-07T09:55:00.000Z')
+    }))
+
+    const result = await finalizeClaimedOutboxEntries(
+      null,
+      [insertedId],
+      'worker-1',
+      SENT,
+      null,
+      new Date('2026-08-07T10:00:00.000Z')
+    )
+
+    expect(result.matchedCount).toBe(0)
+    expect(await db.collection(collectionName).findOne({ _id: insertedId })).toMatchObject({
+      status: PROCESSING,
+      claimedBy: 'worker-1'
+    })
+  })
+
+  test('returns retryable failures to pending and makes exhausted failures terminal', async () => {
+    const testRunId = `${testRunPrefix}${randomUUID()}`
+    const now = new Date('2026-08-07T10:00:00.000Z')
+    const claimedUntil = new Date('2026-08-07T10:05:00.000Z')
+    const { insertedIds } = await db.collection(collectionName).insertMany([
+      buildEntry(testRunId, {
+        status: PROCESSING,
+        attempts: 0,
+        claimedBy: 'worker-1',
+        claimedAt: now,
+        claimedUntil
+      }),
+      buildEntry(testRunId, {
+        status: PROCESSING,
+        attempts: 2,
+        claimedBy: 'worker-1',
+        claimedAt: now,
+        claimedUntil
+      })
+    ])
+
+    const result = await finalizeClaimedOutboxEntries(
+      null,
+      Object.values(insertedIds),
+      'worker-1',
+      FAILED,
+      'SNS unavailable',
+      new Date('2026-08-07T10:01:00.000Z')
+    )
+    const entries = await db.collection(collectionName)
+      .find({ testRunId })
+      .sort({ attempts: 1 })
+      .toArray()
+
+    expect(result.matchedCount).toBe(2)
+    expect(entries[0]).toMatchObject({ status: PENDING, attempts: 1, error: 'SNS unavailable' })
+    expect(entries[1]).toMatchObject({ status: FAILED, attempts: 3, error: 'SNS unavailable' })
+    expect(entries[0]).not.toHaveProperty('claimedBy')
+    expect(entries[1]).not.toHaveProperty('claimedBy')
+  })
+})

--- a/test/unit/messaging/outbound/crm/publish-pending-messages.test.js
+++ b/test/unit/messaging/outbound/crm/publish-pending-messages.test.js
@@ -1,293 +1,152 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { FAILED } from '../../../../../src/constants/outbox.js'
 
-const mockInfo = vi.fn()
-const mockError = vi.fn()
-vi.mock('../../../../../src/logging/logger.js', () => ({
-  createLogger: () => ({ info: mockInfo, error: mockError })
+const mocks = vi.hoisted(() => ({
+  claim: vi.fn(),
+  finalize: vi.fn(),
+  logTerminal: vi.fn(),
+  updatePublishedAt: vi.fn(),
+  publishBatch: vi.fn(),
+  startSession: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn()
 }))
 
-const { mockConfigGet } = vi.hoisted(() => ({
-  mockConfigGet: vi.fn((key) => {
-    if (key === 'messaging.outboxMaxAttempts') return 2
-    if (key === 'mongo.collections.outbox') return 'outbox'
-    return null
-  })
+vi.mock('../../../../../src/repos/outbox.js', () => ({
+  claimProcessableOutboxEntries: mocks.claim,
+  finalizeClaimedOutboxEntries: mocks.finalize,
+  logTerminalFailuresIfAny: mocks.logTerminal
+}))
+
+vi.mock('../../../../../src/repos/metadata.js', () => ({
+  bulkUpdatePublishedAtDate: mocks.updatePublishedAt
+}))
+
+vi.mock('../../../../../src/messaging/outbound/crm/doc-upload/publish-document-upload-message-batch.js', () => ({
+  publishDocumentUploadMessageBatch: mocks.publishBatch
+}))
+
+vi.mock('../../../../../src/messaging/outbound/outbox-worker-id.js', () => ({
+  outboxWorkerId: 'worker-observability'
+}))
+
+vi.mock('../../../../../src/data/db.js', () => ({
+  client: { startSession: mocks.startSession }
 }))
 
 vi.mock('../../../../../src/config/index.js', () => ({
-  config: { get: mockConfigGet }
-}))
-
-const { mockLogTerminalFailuresIfAny } = vi.hoisted(() => ({
-  mockLogTerminalFailuresIfAny: vi.fn().mockResolvedValue(undefined)
-}))
-
-const mockGetProcessable = vi.fn()
-vi.mock('../../../../../src/repos/outbox.js', () => ({
-  getProcessableOutboxEntries: () => mockGetProcessable(),
-  bulkUpdateDeliveryStatus: vi.fn(),
-  logTerminalFailuresIfAny: mockLogTerminalFailuresIfAny
-}))
-
-const mockBulkUpdatePublishedAtDate = vi.fn()
-vi.mock('../../../../../src/repos/metadata.js', () => ({
-  bulkUpdatePublishedAtDate: (...args) => mockBulkUpdatePublishedAtDate(...args)
-}))
-
-const mockPublishBatch = vi.fn()
-vi.mock('../../../../../src/messaging/outbound/crm/doc-upload/publish-document-upload-message-batch.js', () => ({
-  publishDocumentUploadMessageBatch: (...args) => mockPublishBatch(...args)
-}))
-
-const mockStartSession = vi.fn()
-vi.mock('../../../../../src/data/db.js', () => ({
-  client: { startSession: () => mockStartSession() }
-}))
-
-let publishPendingMessages
-let bulkUpdateDeliveryStatus
-
-describe('publishPendingMessages', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockLogTerminalFailuresIfAny.mockResolvedValue(undefined)
-    mockConfigGet.mockImplementation((key) => {
+  config: {
+    get: vi.fn(key => {
       if (key === 'messaging.outboxMaxAttempts') return 2
       if (key === 'mongo.collections.outbox') return 'outbox'
       return null
     })
-    // default session mock
-    const session = {
-      withTransaction: vi.fn(async (cb) => cb()),
+  }
+}))
+
+vi.mock('../../../../../src/logging/logger.js', () => ({
+  createLogger: () => ({
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError
+  })
+}))
+
+const { publishPendingMessages } = await import('../../../../../src/messaging/outbound/crm/doc-upload/publish-pending-messages.js')
+
+const buildEntry = (id, attempts) => ({
+  _id: `outbox-${id}`,
+  payload: { file: { fileId: `file-${id}` } },
+  attempts,
+  claimedBy: 'worker-observability',
+  claimedAt: new Date('2026-08-07T10:00:00.000Z'),
+  claimedUntil: new Date('2026-08-07T10:05:00.000Z')
+})
+
+describe('publishPendingMessages observability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.startSession.mockReturnValue({
+      withTransaction: vi.fn(async callback => callback()),
       endSession: vi.fn()
-    }
-    mockStartSession.mockReturnValue(session)
-    // dynamically import the module under test after mocks are set up
-    return (async () => {
-      const mod = await import('../../../../../src/messaging/outbound/crm/doc-upload/publish-pending-messages.js')
-      publishPendingMessages = mod.publishPendingMessages
-      const outbox = await import('../../../../../src/repos/outbox.js')
-      bulkUpdateDeliveryStatus = outbox.bulkUpdateDeliveryStatus
-    })()
-  })
-
-  test('returns early when no pending messages', async () => {
-    mockGetProcessable.mockResolvedValue([])
-    await publishPendingMessages()
-    expect(mockInfo).toHaveBeenCalled()
-    // ensure no publish calls
-    expect(mockPublishBatch).not.toHaveBeenCalled()
-  })
-
-  test('processes successful messages and updates status and publishedAt', async () => {
-    const entry = { messageId: 'm1', _id: 'id1' }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [{ Id: 'm1' }], Failed: [] })
-
-    await publishPendingMessages()
-
-    expect(mockPublishBatch).toHaveBeenCalled()
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalled()
-    expect(mockBulkUpdatePublishedAtDate).toHaveBeenCalled()
-    expect(mockInfo).toHaveBeenCalled()
-  })
-
-  test('logs imminent terminal failures when attempts reach maxAttempts', async () => {
-    const entry = { messageId: 'm2', _id: 'id2', attempts: 1 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'm2', Message: 'boom' }] })
-
-    await publishPendingMessages()
-
-    // bulk update should have been called for failed
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalled()
-    // logger.error should be called for imminent terminal
-    const calledWith = mockError.mock.calls.find(call => JSON.stringify(call[0]).includes('outbox_terminal_failure_imminent'))
-    expect(calledWith).toBeDefined()
-  })
-
-  test('resolves when publishDocumentUploadMessageBatch returns all Failed — treats entries as failed', async () => {
-    mockGetProcessable.mockResolvedValue([{ messageId: 'm3', payload: { file: { fileId: 'f3' } } }])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'f3', Code: 'PublishError', Message: 'sns down' }] })
-
-    await expect(publishPendingMessages()).resolves.not.toThrow()
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(expect.anything(), ['f3'], FAILED, 'Failed to send message')
-    expect(mockLogTerminalFailuresIfAny).toHaveBeenCalled()
-  })
-
-  test('uses payload.file.fileId when logging imminent terminal failures', async () => {
-    const entry = {
-      _id: 'id-file',
-      payload: { file: { fileId: 'file-1' } },
-      attempts: 1
-    }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'file-1', Code: 'sns_error' }] })
-
-    await publishPendingMessages()
-
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
-    )
-    expect(imminentLog).toBeDefined()
-    expect(imminentLog[0].event.entryId).toBe('file-1')
-    expect(imminentLog[0].event.reason).toBe('sns_error')
-  })
-
-  test('does not log imminent terminal failure when attempts remain below max', async () => {
-    const entry = { messageId: 'm4', _id: 'id4', attempts: 0 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'm4' }] })
-
-    await publishPendingMessages()
-
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
-    )
-    expect(imminentLog).toBeUndefined()
-  })
-
-  test('uses failure message when logging imminent terminal failures', async () => {
-    const entry = { messageId: 'm-msg', _id: 'id-msg', attempts: 1 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'm-msg', Message: 'sns down' }] })
-
-    await publishPendingMessages()
-
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
-    )
-    expect(imminentLog[0].event.reason).toBe('sns down')
-    expect(imminentLog[0].event.attempts).toBe(2)
-  })
-
-  test('defaults imminent terminal reason when failure has no message or code', async () => {
-    const entry = { messageId: 'm5', _id: 'id5', attempts: 1 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'm5' }] })
-
-    await publishPendingMessages()
-
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
-    )
-    expect(imminentLog[0].event.reason).toBe('failed_to_publish')
-  })
-
-  test('processes failed batch without successful updates', async () => {
-    const entry = { messageId: 'm6', _id: 'id6', attempts: 0 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'm6', Message: 'failed' }] })
-
-    await publishPendingMessages()
-
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(
-      expect.anything(),
-      ['m6'],
-      FAILED,
-      'Failed to send message'
-    )
-    expect(mockBulkUpdatePublishedAtDate).not.toHaveBeenCalled()
-  })
-
-  test('falls back to default failure reason when failed metadata cannot be matched', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'messaging.outboxMaxAttempts') return 1
-      return null
     })
-    const entry = { attempts: 0 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{}] })
+    mocks.finalize.mockResolvedValue({ acknowledged: true, matchedCount: 1 })
+    mocks.logTerminal.mockResolvedValue(undefined)
+  })
+
+  test('logs claim ownership fields for every claimed entry', async () => {
+    const entry = buildEntry('claimed', 0)
+    mocks.claim.mockResolvedValue([entry])
+    mocks.publishBatch.mockResolvedValue({ Successful: [], Failed: [] })
 
     await publishPendingMessages()
 
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'outbox_claimed',
+          reference: 'outbox-claimed',
+          entryId: 'file-claimed',
+          claimedBy: 'worker-observability',
+          claimedAt: entry.claimedAt,
+          claimedUntil: entry.claimedUntil
+        })
+      }),
+      'Outbox entry claimed for processing'
     )
-    expect(imminentLog[0].event.entryId).toBeNull()
-    expect(imminentLog[0].event.reason).toBe('failed_to_publish')
   })
 
-  test('resolves imminent terminal entry id from payload file id when present', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'messaging.outboxMaxAttempts') return 1
-      return null
+  test('logs retryable and terminal failure finalizations separately', async () => {
+    const retryable = buildEntry('retryable', 0)
+    const terminal = buildEntry('terminal', 1)
+    mocks.claim.mockResolvedValue([retryable, terminal])
+    mocks.publishBatch.mockResolvedValue({
+      Successful: [],
+      Failed: [
+        { Id: 'file-retryable', Message: 'temporary failure' },
+        { Id: 'file-terminal', Code: 'terminal_failure' }
+      ]
     })
-    const entry = {
-      payload: { file: { fileId: 'file-only' } },
-      messageId: 'message-only',
-      attempts: 0
-    }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'file-only' }] })
 
     await publishPendingMessages()
 
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ event: expect.objectContaining({ type: 'outbox_finalized', status: 'PENDING' }) }),
+      'Outbox entry finalized as PENDING'
     )
-    expect(imminentLog[0].event.entryId).toBe('file-only')
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ event: expect.objectContaining({ type: 'outbox_finalized', status: 'FAILED' }) }),
+      'Outbox entry finalized as FAILED'
+    )
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'outbox_terminal_failure_imminent',
+          entryId: 'file-terminal',
+          attempts: 2,
+          reason: 'terminal_failure'
+        })
+      }),
+      'Outbox entry will reach FAILED after this attempt'
+    )
   })
 
-  test('resolves imminent terminal entry id from messageId when file id is absent', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'messaging.outboxMaxAttempts') return 1
-      return null
+  test('does not emit terminal audit lookup when failed finalization is rejected', async () => {
+    const entry = buildEntry('expired', 1)
+    mocks.claim.mockResolvedValue([entry])
+    mocks.publishBatch.mockResolvedValue({
+      Successful: [],
+      Failed: [{ Id: 'file-expired' }]
     })
-    const entry = {
-      payload: { file: {} },
-      messageId: 'message-only',
-      attempts: undefined
-    }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'message-only' }] })
+    mocks.finalize.mockResolvedValue({ acknowledged: true, matchedCount: 0 })
 
     await publishPendingMessages()
 
-    const imminentLog = mockError.mock.calls.find(call =>
-      call[0]?.event?.type === 'outbox_terminal_failure_imminent'
+    expect(mocks.logTerminal).not.toHaveBeenCalled()
+    expect(mocks.loggerError).not.toHaveBeenCalled()
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: expect.objectContaining({ type: 'outbox_finalization_rejected' }) }),
+      'Outbox entry could not be finalized by this worker'
     )
-    expect(imminentLog[0].event.entryId).toBe('message-only')
-    expect(imminentLog[0].event.attempts).toBe(1)
-    expect(imminentLog[0].event.reference).toBeUndefined()
-  })
-
-  test('processes messages in batches of ten', async () => {
-    const entries = Array.from({ length: 11 }, (_, i) => ({ messageId: `m${i}`, _id: `id${i}` }))
-    mockGetProcessable.mockResolvedValue(entries)
-    mockPublishBatch.mockResolvedValue({ Successful: [{ Id: 'm0' }], Failed: [] })
-
-    await publishPendingMessages()
-
-    expect(mockPublishBatch).toHaveBeenCalledTimes(2)
-    expect(mockPublishBatch.mock.calls[0][0]).toHaveLength(10)
-    expect(mockPublishBatch.mock.calls[1][0]).toHaveLength(1)
-  })
-
-  test('calls logTerminalFailuresIfAny after withTransaction resolves when there are failures', async () => {
-    const entry = { messageId: 'm7', _id: 'id7', attempts: 1 }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'm7' }] })
-
-    await publishPendingMessages()
-
-    expect(mockLogTerminalFailuresIfAny).toHaveBeenCalledWith(
-      'outbox',
-      ['m7'],
-      2,
-      null,
-      'Failed to send message'
-    )
-  })
-
-  test('does not call logTerminalFailuresIfAny when Failed is empty', async () => {
-    const entry = { messageId: 'm8', _id: 'id8' }
-    mockGetProcessable.mockResolvedValue([entry])
-    mockPublishBatch.mockResolvedValue({ Successful: [{ Id: 'm8' }], Failed: [] })
-
-    await publishPendingMessages()
-
-    expect(mockLogTerminalFailuresIfAny).not.toHaveBeenCalled()
   })
 })

--- a/test/unit/messaging/outbound/publish-pending-messages.test.js
+++ b/test/unit/messaging/outbound/publish-pending-messages.test.js
@@ -1,312 +1,206 @@
-import { beforeEach, describe, expect, vi, test } from 'vitest'
-import { publishPendingMessages } from '../../../../src/messaging/outbound/crm/doc-upload/publish-pending-messages.js'
-import { getProcessableOutboxEntries, bulkUpdateDeliveryStatus } from '../../../../src/repos/outbox.js'
-import { bulkUpdatePublishedAtDate } from '../../../../src/repos/metadata.js'
-import { publishDocumentUploadMessageBatch } from '../../../../src/messaging/outbound/crm/doc-upload/publish-document-upload-message-batch.js'
-import { client } from '../../../../src/data/db.js'
-import { SENT, FAILED } from '../../../../src/constants/outbox.js'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-vi.mock('../../../../src/data/db.js', () => ({
-  db: { collection: vi.fn() },
-  client: {
-    startSession: vi.fn()
-  }
+import { FAILED, SENT } from '../../../../src/constants/outbox.js'
+
+const mocks = vi.hoisted(() => ({
+  claim: vi.fn(),
+  finalize: vi.fn(),
+  logTerminal: vi.fn(),
+  updatePublishedAt: vi.fn(),
+  publishBatch: vi.fn(),
+  startSession: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+  configGet: vi.fn((key) => {
+    if (key === 'messaging.outboxMaxAttempts') return 2
+    if (key === 'mongo.collections.outbox') return 'outbox'
+    return null
+  })
 }))
 
 vi.mock('../../../../src/repos/outbox.js', () => ({
-  getProcessableOutboxEntries: vi.fn(),
-  bulkUpdateDeliveryStatus: vi.fn(),
-  logTerminalFailuresIfAny: vi.fn().mockResolvedValue(undefined)
+  claimProcessableOutboxEntries: mocks.claim,
+  finalizeClaimedOutboxEntries: mocks.finalize,
+  logTerminalFailuresIfAny: mocks.logTerminal
 }))
-vi.mock('../../../../src/messaging/outbound/crm/doc-upload/publish-document-upload-message-batch.js')
-vi.mock('../../../../src/repos/metadata.js')
+
+vi.mock('../../../../src/repos/metadata.js', () => ({
+  bulkUpdatePublishedAtDate: mocks.updatePublishedAt
+}))
+
+vi.mock('../../../../src/messaging/outbound/crm/doc-upload/publish-document-upload-message-batch.js', () => ({
+  publishDocumentUploadMessageBatch: mocks.publishBatch
+}))
+
+vi.mock('../../../../src/messaging/outbound/outbox-worker-id.js', () => ({
+  outboxWorkerId: 'worker-1'
+}))
+
+vi.mock('../../../../src/data/db.js', () => ({
+  client: { startSession: mocks.startSession }
+}))
+
 vi.mock('../../../../src/config/index.js', () => ({
-  config: {
-    get: vi.fn((key) => {
-      if (key === 'mongo.collections.outbox') return 'outbox'
-      if (key === 'aws.messaging.topics.documentUploadEvents') {
-        return 'arn:aws:sns:eu-west-2:000000000000:fcp_sfd_object_processor_events'
-      }
-      if (key === 'messaging.outboxMaxAttempts') return 2
-      return null
-    })
-  }
+  config: { get: mocks.configGet }
 }))
 
 vi.mock('../../../../src/logging/logger.js', () => ({
-  createLogger: vi.fn().mockReturnValue({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn()
+  createLogger: () => ({
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError
   })
 }))
 
-describe('publishPendingMessages', () => {
-  let mockSession
+const { publishPendingMessages } = await import('../../../../src/messaging/outbound/crm/doc-upload/publish-pending-messages.js')
 
-  const mockPendingMessages = [
-    {
-      _id: 'message-id-1',
-      messageId: 'metadata-id-1',
-      payload: {
-        metadata: { sbi: '123456789' },
-        file: { fileId: 'file-1', filename: 'test1.pdf' }
-      },
-      status: 'pending',
-      attempts: 0,
-      createdAt: new Date()
-    },
-    {
-      _id: 'message-id-2',
-      messageId: 'metadata-id-2',
-      payload: {
-        metadata: { sbi: '987654321' },
-        file: { fileId: 'file-2', filename: 'test2.pdf' }
-      },
-      status: 'pending',
-      attempts: 0,
-      createdAt: new Date()
-    }
-  ]
+const buildEntry = (id, attempts = 0) => ({
+  _id: `outbox-${id}`,
+  messageId: `metadata-${id}`,
+  payload: { file: { fileId: `file-${id}` } },
+  status: 'PROCESSING',
+  attempts,
+  claimedBy: 'worker-1',
+  claimedAt: new Date('2026-08-07T10:00:00.000Z'),
+  claimedUntil: new Date('2026-08-07T10:05:00.000Z')
+})
+
+describe('publishPendingMessages', () => {
+  let session
 
   beforeEach(() => {
     vi.clearAllMocks()
-
-    mockSession = {
-      withTransaction: vi.fn((callback) => callback()),
+    session = {
+      withTransaction: vi.fn(async callback => callback()),
       endSession: vi.fn()
     }
-
-    client.startSession.mockReturnValue(mockSession)
+    mocks.startSession.mockReturnValue(session)
+    mocks.finalize.mockResolvedValue({ acknowledged: true, matchedCount: 1 })
+    mocks.logTerminal.mockResolvedValue(undefined)
+    mocks.updatePublishedAt.mockResolvedValue({ acknowledged: true })
+    mocks.publishBatch.mockResolvedValue({ Successful: [], Failed: [] })
   })
 
-  test('should fetch pending messages and publish them', async () => {
-    getProcessableOutboxEntries.mockResolvedValue(mockPendingMessages)
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [{ Id: 'id-1', messageId: 'message-id-1', SequenceNumber: 1 }],
-      Failed: [{ Id: 'id-2', messageId: 'message-id-2', SequenceNumber: 2 }]
+  test('claims with the process worker ID and finalizes SNS results by outbox ID', async () => {
+    const successfulEntry = buildEntry('success')
+    const failedEntry = buildEntry('failure')
+    mocks.claim.mockResolvedValue([successfulEntry, failedEntry])
+    mocks.publishBatch.mockResolvedValue({
+      Successful: [{ Id: 'file-success' }],
+      Failed: [{ Id: 'file-failure', Message: 'SNS unavailable' }]
     })
 
     await publishPendingMessages()
 
-    expect(getProcessableOutboxEntries).toHaveBeenCalledOnce()
-  })
-
-  test('should process messages in batches of 10 when more than batch size returned from getProcessableOutboxEntries', async () => {
-    // Create 25 mock messages
-    const largeBatch = Array.from({ length: 25 }, (_, index) => ({
-      _id: `message-id-${index}`,
-      messageId: `metadata-id-${index}`,
-      payload: {
-        metadata: { sbi: `${123456789 + index}` },
-        file: { fileId: `file-${index}`, filename: `test${index}.pdf` }
-      },
-      status: 'pending',
-      attempts: 0,
-      createdAt: new Date()
-    }))
-
-    getProcessableOutboxEntries.mockResolvedValue(largeBatch)
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [],
-      Failed: []
-    })
-
-    await publishPendingMessages()
-
-    expect(getProcessableOutboxEntries).toHaveBeenCalledOnce()
-
-    // Should be called 3 times: 10 + 10 + 5
-    expect(publishDocumentUploadMessageBatch).toHaveBeenCalledTimes(3)
-
-    // First batch: messages 0-9 (10 messages)
-    expect(publishDocumentUploadMessageBatch).toHaveBeenNthCalledWith(1, largeBatch.slice(0, 10))
-
-    // Second batch: messages 10-19 (10 messages)
-    expect(publishDocumentUploadMessageBatch).toHaveBeenNthCalledWith(2, largeBatch.slice(10, 20))
-
-    // Third batch: messages 20-24 (5 messages)
-    expect(publishDocumentUploadMessageBatch).toHaveBeenNthCalledWith(3, largeBatch.slice(20, 25))
-  })
-
-  test('should handle when there are no pending messages', async () => {
-    getProcessableOutboxEntries.mockResolvedValue([])
-
-    await publishPendingMessages()
-
-    expect(getProcessableOutboxEntries).toHaveBeenCalledOnce()
-    expect(publishDocumentUploadMessageBatch).not.toHaveBeenCalled()
-    expect(bulkUpdateDeliveryStatus).not.toHaveBeenCalled()
-    expect(bulkUpdatePublishedAtDate).not.toHaveBeenCalled()
-  })
-
-  test('should update status to FAILED when publishDocumentUploadMessageBatch returns Failed messages', async () => {
-    getProcessableOutboxEntries.mockResolvedValue(mockPendingMessages)
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [],
-      Failed: [{ Id: 'message-id-1', messageId: 'sns-message-id', SequenceNumber: 1 }]
-    })
-    await publishPendingMessages()
-
-    expect(getProcessableOutboxEntries).toHaveBeenCalledOnce()
-    expect(publishDocumentUploadMessageBatch).toHaveBeenCalledTimes(1)
-
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledTimes(1)
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(mockSession, ['message-id-1'], FAILED, 'Failed to send message')
-    expect(bulkUpdatePublishedAtDate).not.toHaveBeenCalled()
-  })
-
-  test('should allow transient failure to be recovered on subsequent run', async () => {
-    // Arrange: only one pending message returned each run
-    const singleMessage = [mockPendingMessages[0]]
-    getProcessableOutboxEntries
-      .mockResolvedValueOnce(singleMessage)
-      .mockResolvedValueOnce(singleMessage)
-
-    // First run: publishing fails for the message
-    publishDocumentUploadMessageBatch
-      .mockResolvedValueOnce({ Successful: [], Failed: [{ Id: 'message-id-1' }] })
-      // Second run: publishing succeeds
-      .mockResolvedValueOnce({ Successful: [{ Id: 'message-id-1' }], Failed: [] })
-
-    // Act: run twice to simulate retry window
-    await publishPendingMessages()
-    await publishPendingMessages()
-
-    // Assert: first call records failure, second call marks as SENT and updates publishedAt
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledTimes(2)
-    expect(bulkUpdateDeliveryStatus).toHaveBeenNthCalledWith(1, mockSession, ['message-id-1'], FAILED, 'Failed to send message')
-    expect(bulkUpdateDeliveryStatus).toHaveBeenNthCalledWith(2, mockSession, ['message-id-1'], SENT)
-    expect(bulkUpdatePublishedAtDate).toHaveBeenCalledTimes(1)
-  })
-
-  test('should resolve and treat all entries as failed when publishDocumentUploadMessageBatch returns all Failed', async () => {
-    getProcessableOutboxEntries.mockResolvedValue(mockPendingMessages)
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [],
-      Failed: mockPendingMessages.map(e => ({ Id: e.payload.file.fileId, Code: 'Error', Message: 'sns down' }))
-    })
-
-    await expect(publishPendingMessages()).resolves.not.toThrow()
-
-    expect(getProcessableOutboxEntries).toHaveBeenCalledOnce()
-    expect(publishDocumentUploadMessageBatch).toHaveBeenCalledTimes(1)
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(
-      mockSession,
-      expect.arrayContaining([mockPendingMessages[0].payload.file.fileId, mockPendingMessages[1].payload.file.fileId]),
+    expect(mocks.claim).toHaveBeenCalledWith('worker-1')
+    expect(mocks.finalize).toHaveBeenNthCalledWith(
+      1,
+      session,
+      ['outbox-success'],
+      'worker-1',
+      SENT,
+      null
+    )
+    expect(mocks.finalize).toHaveBeenNthCalledWith(
+      2,
+      session,
+      ['outbox-failure'],
+      'worker-1',
       FAILED,
       'Failed to send message'
     )
-    expect(mockSession.endSession).toHaveBeenCalledOnce()
+    expect(mocks.updatePublishedAt).toHaveBeenCalledWith(session, ['file-success'])
+    expect(mocks.logTerminal).toHaveBeenCalledWith(
+      'outbox',
+      ['file-failure'],
+      2,
+      null,
+      'Failed to send message'
+    )
+    expect(session.withTransaction).toHaveBeenCalledOnce()
+    expect(session.endSession).toHaveBeenCalledOnce()
   })
 
-  test('should use transaction session for database operations', async () => {
-    getProcessableOutboxEntries.mockResolvedValue(mockPendingMessages)
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [
-        { Id: mockPendingMessages[0].messageId }, { Id: mockPendingMessages[1].messageId }
-      ],
+  test('does not publish when no entries can be claimed', async () => {
+    mocks.claim.mockResolvedValue([])
+
+    await publishPendingMessages()
+
+    expect(mocks.publishBatch).not.toHaveBeenCalled()
+    expect(mocks.finalize).not.toHaveBeenCalled()
+    expect(session.endSession).toHaveBeenCalledOnce()
+  })
+
+  test('preserves SNS batches of ten', async () => {
+    const entries = Array.from({ length: 21 }, (_, index) => buildEntry(index))
+    mocks.claim.mockResolvedValue(entries)
+
+    await publishPendingMessages()
+
+    expect(mocks.publishBatch).toHaveBeenCalledTimes(3)
+    expect(mocks.publishBatch).toHaveBeenNthCalledWith(1, entries.slice(0, 10))
+    expect(mocks.publishBatch).toHaveBeenNthCalledWith(2, entries.slice(10, 20))
+    expect(mocks.publishBatch).toHaveBeenNthCalledWith(3, entries.slice(20))
+  })
+
+  test('updates metadata only for successful entries whose claims are finalized', async () => {
+    const accepted = buildEntry('accepted')
+    const rejected = buildEntry('rejected')
+    mocks.claim.mockResolvedValue([accepted, rejected])
+    mocks.publishBatch.mockResolvedValue({
+      Successful: [{ Id: 'file-accepted' }, { Id: 'file-rejected' }],
+      Failed: []
+    })
+    mocks.finalize
+      .mockResolvedValueOnce({ acknowledged: true, matchedCount: 1 })
+      .mockResolvedValueOnce({ acknowledged: true, matchedCount: 0 })
+
+    await publishPendingMessages()
+
+    expect(mocks.updatePublishedAt).toHaveBeenCalledWith(session, ['file-accepted'])
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'outbox_finalization_rejected',
+          reference: 'outbox-rejected',
+          claimedBy: 'worker-1'
+        })
+      }),
+      'Outbox entry could not be finalized by this worker'
+    )
+  })
+
+  test('leaves unmatched SNS results claimed for lease recovery and logs them', async () => {
+    mocks.claim.mockResolvedValue([buildEntry('known')])
+    mocks.publishBatch.mockResolvedValue({
+      Successful: [{ Id: 'file-unknown' }],
       Failed: []
     })
 
     await publishPendingMessages()
 
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(mockSession, [mockPendingMessages[0].messageId, mockPendingMessages[1].messageId], SENT)
-    expect(bulkUpdatePublishedAtDate).toHaveBeenCalledWith(mockSession, [mockPendingMessages[0].messageId, mockPendingMessages[1].messageId])
+    expect(mocks.finalize).not.toHaveBeenCalled()
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'outbox_publish_result_unmatched',
+          entryId: 'file-unknown'
+        })
+      }),
+      'SNS publish result did not match a claimed outbox entry'
+    )
   })
 
-  test('should end session even if error occurs', async () => {
-    const mockError = new Error('Database error')
-    getProcessableOutboxEntries.mockRejectedValue(mockError)
+  test('ends the session and rethrows claim errors', async () => {
+    mocks.claim.mockRejectedValue(new Error('Mongo unavailable'))
 
-    await expect(publishPendingMessages()).rejects.toThrow('Database error')
+    await expect(publishPendingMessages()).rejects.toThrow('Mongo unavailable')
 
-    expect(mockSession.endSession).toHaveBeenCalledOnce()
-  })
-
-  test('should log imminent terminal failures when attempts reach maxAttempts', async () => {
-    const { createLogger } = await import('../../../../src/logging/logger.js')
-    const logger = createLogger()
-
-    const imminentMessage = [
-      {
-        _id: 'imminent-id',
-        messageId: 'metadata-id-imminent',
-        payload: {
-          metadata: { sbi: '111111111' },
-          file: { fileId: 'file-imminent', filename: 'imminent.pdf' }
-        },
-        status: 'pending',
-        attempts: 1,
-        createdAt: new Date()
-      }
-    ]
-
-    // attempts = 1, outboxMaxAttempts mocked to 2 => (1 || 0) + 1 >= 2 true
-    getProcessableOutboxEntries.mockResolvedValue(imminentMessage)
-
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [],
-      Failed: [{ Id: 'file-imminent', Message: 'SNS failure' }]
-    })
-
-    await publishPendingMessages()
-
-    expect(logger.error).toHaveBeenCalled()
-    const callArgs = logger.error.mock.calls[0][0]
-    expect(callArgs.event).toBeDefined()
-    expect(callArgs.event.type).toBe('outbox_terminal_failure_imminent')
-  })
-
-  test('should map entries without payload.file using messageId and update statuses accordingly', async () => {
-    const entries = [
-      {
-        _id: 'm1',
-        messageId: 'meta-1',
-        payload: { metadata: { sbi: '1' } },
-        attempts: 0
-      },
-      {
-        _id: 'm2',
-        messageId: 'meta-2',
-        payload: { metadata: { sbi: '2' } },
-        attempts: 0
-      }
-    ]
-
-    getProcessableOutboxEntries.mockResolvedValue(entries)
-
-    // SNS returns Ids that match the messageId values
-    publishDocumentUploadMessageBatch.mockResolvedValue({
-      Successful: [{ Id: 'meta-1' }],
-      Failed: [{ Id: 'meta-2' }]
-    })
-
-    await publishPendingMessages()
-
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(mockSession, ['meta-1'], SENT)
-    expect(bulkUpdatePublishedAtDate).toHaveBeenCalledWith(mockSession, ['meta-1'])
-    expect(bulkUpdateDeliveryStatus).toHaveBeenCalledWith(mockSession, ['meta-2'], FAILED, 'Failed to send message')
-  })
-
-  test('should NOT log imminent terminal failures when attempts remain below max', async () => {
-    const { createLogger } = await import('../../../../src/logging/logger.js')
-    const logger = createLogger()
-
-    const msg = [
-      {
-        _id: 'no-imminent',
-        messageId: 'meta-no',
-        payload: { file: { fileId: 'file-no' } },
-        attempts: 0
-      }
-    ]
-
-    getProcessableOutboxEntries.mockResolvedValue(msg)
-    publishDocumentUploadMessageBatch.mockResolvedValue({ Successful: [], Failed: [{ Id: 'file-no' }] })
-
-    await publishPendingMessages()
-
-    expect(logger.error).not.toHaveBeenCalled()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Error publishing pending outbox messages'
+    )
+    expect(session.endSession).toHaveBeenCalledOnce()
   })
 })

--- a/test/unit/repos/outbox-claims.test.js
+++ b/test/unit/repos/outbox-claims.test.js
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  collection: vi.fn(),
+  loggerWarn: vi.fn(),
+  configGet: vi.fn((key) => {
+    switch (key) {
+      case 'mongo.collections.outbox': return 'outbox'
+      case 'mongo.outboxQueryLimit': return 2
+      case 'messaging.outboxMaxAttempts': return 3
+      case 'messaging.outboxClaimLeaseMs': return 300000
+      default: return null
+    }
+  })
+}))
+
+vi.mock('../../../src/config/index.js', () => ({
+  config: { get: mocks.configGet }
+}))
+
+vi.mock('../../../src/data/db.js', () => ({
+  db: { collection: mocks.collection }
+}))
+
+vi.mock('../../../src/logging/logger.js', () => ({
+  createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: mocks.loggerWarn })
+}))
+
+vi.mock('../../../src/messaging/outbound/audit/send-audit-event.js', () => ({
+  sendAuditEvent: vi.fn()
+}))
+
+const {
+  claimProcessableOutboxEntries,
+  finalizeClaimedOutboxEntries
+} = await import('../../../src/repos/outbox.js')
+
+describe('outbox claims', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('atomically claims eligible entries oldest first up to the query limit', async () => {
+    const now = new Date('2026-08-07T10:00:00.000Z')
+    const claimedUntil = new Date('2026-08-07T10:05:00.000Z')
+    const findOneAndUpdate = vi.fn()
+      .mockResolvedValueOnce({ _id: 'entry-1', status: 'PENDING', createdAt: new Date('2026-08-07T09:00:00.000Z') })
+      .mockResolvedValueOnce({ _id: 'entry-2', status: 'PENDING', createdAt: new Date('2026-08-07T09:01:00.000Z') })
+    mocks.collection.mockReturnValue({ findOneAndUpdate })
+
+    const result = await claimProcessableOutboxEntries('worker-1', now)
+
+    expect(findOneAndUpdate).toHaveBeenCalledTimes(2)
+    expect(findOneAndUpdate).toHaveBeenCalledWith({
+      attempts: { $lt: 3 },
+      $or: [
+        { status: 'PENDING' },
+        { status: 'PROCESSING', claimedUntil: { $lt: now } }
+      ]
+    }, {
+      $set: {
+        status: 'PROCESSING',
+        claimedAt: now,
+        claimedUntil,
+        claimedBy: 'worker-1'
+      }
+    }, {
+      sort: { createdAt: 1 },
+      returnDocument: 'before'
+    })
+    expect(result).toEqual([
+      expect.objectContaining({ _id: 'entry-1', status: 'PROCESSING', claimedBy: 'worker-1', claimedUntil }),
+      expect.objectContaining({ _id: 'entry-2', status: 'PROCESSING', claimedBy: 'worker-1', claimedUntil })
+    ])
+  })
+
+  test('stops claiming when no eligible entry remains', async () => {
+    const findOneAndUpdate = vi.fn()
+      .mockResolvedValueOnce({ _id: 'entry-1', status: 'PENDING' })
+      .mockResolvedValueOnce(null)
+    mocks.collection.mockReturnValue({ findOneAndUpdate })
+
+    const result = await claimProcessableOutboxEntries('worker-1')
+
+    expect(result).toHaveLength(1)
+    expect(findOneAndUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  test('logs when an expired processing claim is reclaimed', async () => {
+    const expiredClaim = {
+      _id: { toString: () => 'entry-1' },
+      status: 'PROCESSING',
+      claimedBy: 'worker-old',
+      claimedUntil: new Date('2026-08-07T09:59:00.000Z')
+    }
+    mocks.collection.mockReturnValue({
+      findOneAndUpdate: vi.fn()
+        .mockResolvedValueOnce(expiredClaim)
+        .mockResolvedValueOnce(null)
+    })
+
+    await claimProcessableOutboxEntries('worker-new', new Date('2026-08-07T10:00:00.000Z'))
+
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'outbox_claim_reclaimed',
+          reference: 'entry-1',
+          previousClaimedBy: 'worker-old',
+          claimedBy: 'worker-new'
+        })
+      }),
+      'Reclaimed expired outbox claim'
+    )
+  })
+
+  test('finalizes successful entries only while the worker owns a valid claim', async () => {
+    const now = new Date('2026-08-07T10:00:00.000Z')
+    const updateMany = vi.fn().mockResolvedValue({ acknowledged: true, matchedCount: 2 })
+    mocks.collection.mockReturnValue({ updateMany })
+    const session = { id: 'session-1' }
+
+    const result = await finalizeClaimedOutboxEntries(
+      session,
+      ['entry-1', 'entry-2'],
+      'worker-1',
+      'SENT',
+      null,
+      now
+    )
+
+    expect(updateMany).toHaveBeenCalledWith({
+      _id: { $in: ['entry-1', 'entry-2'] },
+      status: 'PROCESSING',
+      claimedBy: 'worker-1',
+      claimedUntil: { $gt: now }
+    }, {
+      $set: { status: 'SENT', lastAttemptedAt: now },
+      $inc: { attempts: 1 },
+      $unset: { claimedAt: '', claimedUntil: '', claimedBy: '', error: '' }
+    }, { session })
+    expect(result.matchedCount).toBe(2)
+  })
+
+  test('finalizes failed attempts with retry and terminal status pipeline', async () => {
+    const now = new Date('2026-08-07T10:00:00.000Z')
+    const updateMany = vi.fn().mockResolvedValue({ acknowledged: true })
+    mocks.collection.mockReturnValue({ updateMany })
+
+    await finalizeClaimedOutboxEntries(
+      null,
+      ['entry-1'],
+      'worker-1',
+      'FAILED',
+      'SNS unavailable',
+      now
+    )
+
+    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'PROCESSING',
+      claimedBy: 'worker-1',
+      claimedUntil: { $gt: now }
+    }), [
+      {
+        $set: {
+          attempts: { $add: [{ $ifNull: ['$attempts', 0] }, 1] },
+          lastAttemptedAt: now,
+          error: 'SNS unavailable'
+        }
+      },
+      {
+        $set: {
+          status: { $cond: [{ $gte: ['$attempts', 3] }, 'FAILED', 'PENDING'] }
+        }
+      },
+      { $unset: ['claimedAt', 'claimedUntil', 'claimedBy'] }
+    ], {})
+  })
+
+  test('rejects an unsupported delivery status', async () => {
+    mocks.collection.mockReturnValue({ updateMany: vi.fn() })
+
+    await expect(finalizeClaimedOutboxEntries(
+      null,
+      ['entry-1'],
+      'worker-1',
+      'PROCESSING'
+    )).rejects.toThrow('Unsupported outbox delivery status: PROCESSING')
+  })
+
+  test('throws when finalization is not acknowledged', async () => {
+    mocks.collection.mockReturnValue({
+      updateMany: vi.fn().mockResolvedValue({ acknowledged: false })
+    })
+
+    await expect(finalizeClaimedOutboxEntries(
+      null,
+      ['entry-1'],
+      'worker-1',
+      'SENT'
+    )).rejects.toThrow('Failed to finalize claimed outbox entries')
+  })
+})

--- a/test/unit/repos/outbox.test.js
+++ b/test/unit/repos/outbox.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/no-multiple-empty-lines */
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 vi.mock('../../../src/config/index.js', () => {
@@ -35,8 +34,6 @@ const { config } = await import('../../../src/config/index.js')
 const { db } = await import('../../../src/data/db.js')
 const {
   createOutboxEntries,
-  getProcessableOutboxEntries,
-  bulkUpdateDeliveryStatus,
   logTerminalFailuresIfAny
 } = await import('../../../src/repos/outbox.js')
 
@@ -81,58 +78,6 @@ describe('src/repos/outbox', () => {
     db.collection.mockReturnValue(collectionObj)
 
     await expect(createOutboxEntries(ids, documents, {})).rejects.toThrow('Failed to insert outbox entries')
-  })
-
-  test('getProcessableOutboxEntries queries with correct filter and returns entries', async () => {
-    const expected = [{ _id: '1' }]
-    const toArray = vi.fn().mockResolvedValue(expected)
-    const limit = vi.fn(() => ({ toArray }))
-    const find = vi.fn(() => ({ limit }))
-    const collectionObj = { find }
-    db.collection.mockReturnValue(collectionObj)
-
-    const res = await getProcessableOutboxEntries()
-    expect(find).toHaveBeenCalled()
-    expect(res).toBe(expected)
-  })
-
-  test('bulkUpdateDeliveryStatus uses sent update path and returns result', async () => {
-    const updateMany = vi.fn().mockResolvedValue({ acknowledged: true })
-    const collectionObj = { updateMany }
-    db.collection.mockReturnValue(collectionObj)
-
-    const session = { id: 's' }
-    const fileIds = ['f1']
-    const res = await bulkUpdateDeliveryStatus(session, fileIds, 'SENT')
-    expect(updateMany).toHaveBeenCalled()
-    expect(res).toEqual({ acknowledged: true })
-  })
-
-  test('bulkUpdateDeliveryStatus uses failure pipeline and returns result', async () => {
-    const updateMany = vi.fn().mockResolvedValue({ acknowledged: true })
-    const collectionObj = { updateMany }
-    db.collection.mockReturnValue(collectionObj)
-
-    const res = await bulkUpdateDeliveryStatus({ id: 's' }, ['f1'], 'FAILED', 'boom')
-    expect(updateMany).toHaveBeenCalled()
-    expect(res).toEqual({ acknowledged: true })
-  })
-
-  test('bulkUpdateDeliveryStatus does not call sendAuditEvent or logTerminalFailuresIfAny', async () => {
-    const updateMany = vi.fn().mockResolvedValue({ acknowledged: true })
-    db.collection.mockReturnValue({ updateMany })
-
-    await bulkUpdateDeliveryStatus({ id: 's' }, ['f1'], 'FAILED', 'boom')
-
-    expect(mockSendAuditEvent).not.toHaveBeenCalled()
-  })
-
-  test('bulkUpdateDeliveryStatus throws when update acknowledged is false', async () => {
-    const updateMany = vi.fn().mockResolvedValue({ acknowledged: false })
-    const collectionObj = { updateMany }
-    db.collection.mockReturnValue(collectionObj)
-
-    await expect(bulkUpdateDeliveryStatus({}, ['f'], 'SENT')).rejects.toThrow('Failed to update outbox entries')
   })
 })
 
@@ -293,5 +238,3 @@ describe('logTerminalFailuresIfAny', () => {
     expect(mockSendAuditEvent).toHaveBeenCalledTimes(2)
   })
 })
-
-

--- a/test/unit/repos/outbox/outbox.test.js
+++ b/test/unit/repos/outbox/outbox.test.js
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, vi, test } from 'vitest'
 import { ObjectId } from 'mongodb'
-import { randomUUID } from 'node:crypto'
 
-import { createOutboxEntries, getProcessableOutboxEntries, bulkUpdateDeliveryStatus } from '../../../../src/repos/outbox.js'
+import { createOutboxEntries } from '../../../../src/repos/outbox.js'
 import { mockMetadataResponse as documents } from '../../../mocks/metadata.js'
-import { PENDING, SENT, FAILED } from '../../../../src/constants/outbox.js'
+import { PENDING } from '../../../../src/constants/outbox.js'
 import { db } from '../../../../src/data/db.js'
 
 vi.mock('../../../../src/data/db.js', () => ({
@@ -216,147 +215,6 @@ describe('Outbox Repository', () => {
 
       expect(mockCollection.insertMany).not.toHaveBeenCalled()
       expect(result).toEqual({})
-    })
-  })
-
-  describe('getProcessableOutboxEntries', () => {
-    test('should retrieve outbox entries with status pending and failed', async () => {
-      const mockPendingEntries = [
-        { _id: new ObjectId(), status: PENDING, payload: {} },
-        { _id: new ObjectId(), status: PENDING, payload: {} },
-        { _id: new ObjectId(), status: FAILED, payload: {} }
-      ]
-
-      // A cursor is what is returned from mongo find operations
-      const mockCursor = {
-        limit: vi.fn().mockReturnThis(),
-        toArray: vi.fn().mockResolvedValue(mockPendingEntries)
-      }
-
-      mockCollection.find.mockReturnValue(mockCursor)
-
-      const result = await getProcessableOutboxEntries()
-
-      expect(db.collection).toHaveBeenCalledWith('outbox')
-      expect(mockCollection.find).toHaveBeenCalledWith({ status: { $in: [PENDING, FAILED] }, attempts: { $lt: 5 } })
-      expect(mockCursor.toArray).toHaveBeenCalled()
-      expect(result).toEqual(mockPendingEntries)
-    })
-
-    test('should return empty array when no pending entries found', async () => {
-      // A cursor is what is returned from mongo find operations
-      const mockCursor = {
-        limit: vi.fn().mockReturnThis(),
-        toArray: vi.fn().mockResolvedValue([])
-      }
-
-      mockCollection.find.mockReturnValue(mockCursor)
-
-      const result = await getProcessableOutboxEntries()
-
-      expect(db.collection).toHaveBeenCalledWith('outbox')
-      expect(mockCollection.find).toHaveBeenCalledWith({ status: { $in: [PENDING, FAILED] }, attempts: { $lt: 5 } })
-      expect(mockCursor.toArray).toHaveBeenCalled()
-      expect(result).toEqual([])
-    })
-
-    test('should apply limit to query', async () => {
-      const mockPendingEntries = [
-        { _id: new ObjectId(), status: PENDING, payload: {} }
-      ]
-
-      const mockCursor = {
-        limit: vi.fn().mockReturnThis(),
-        toArray: vi.fn().mockResolvedValue(mockPendingEntries)
-      }
-
-      mockCollection.find.mockReturnValue(mockCursor)
-
-      const result = await getProcessableOutboxEntries()
-
-      expect(mockCollection.find).toHaveBeenCalledWith({ status: { $in: [PENDING, FAILED] }, attempts: { $lt: 5 } })
-      expect(mockCursor.limit).toHaveBeenCalledWith(expect.any(Number))
-      expect(mockCursor.toArray).toHaveBeenCalled()
-      expect(result).toEqual(mockPendingEntries)
-    })
-  })
-
-  describe('bulkUpdateDeliveryStatus', () => {
-    const mockSession = {}
-
-    test('should update outbox entry status to sent', async () => {
-      const mockUpdateManyResult = {
-        acknowledged: true,
-        matchedCount: 1,
-        modifiedCount: 1,
-        upsertedCount: 0,
-        upsertedId: null
-      }
-
-      mockCollection.updateMany.mockResolvedValue(mockUpdateManyResult)
-      const mockFileId = randomUUID()
-
-      const result = await bulkUpdateDeliveryStatus(mockSession, [mockFileId], SENT)
-
-      // this is the response from the db operation
-      const updatedEntry = mockCollection.updateMany.mock.calls[0]
-
-      expect(updatedEntry[0]).toEqual({ 'payload.file.fileId': { $in: [mockFileId] } })
-      expect(updatedEntry[1].$set).toMatchObject({
-        status: SENT,
-        lastAttemptedAt: expect.any(Date)
-      })
-      expect(updatedEntry[1].$inc).toEqual({ attempts: 1 })
-
-      expect(result).toEqual(mockUpdateManyResult)
-    })
-
-    test('should include error message when outbox entry status to failed', async () => {
-      const mockUpdateManyResult = {
-        acknowledged: true,
-        matchedCount: 1,
-        modifiedCount: 1,
-        upsertedCount: 0,
-        upsertedId: null
-      }
-
-      mockCollection.updateMany.mockResolvedValue(mockUpdateManyResult)
-      const mockFileId = randomUUID()
-      // Mock the cursor returned by find for the terminal logging path
-      const mockCursor = {
-        toArray: vi.fn().mockResolvedValue([])
-      }
-
-      // No potential terminal candidates: countDocuments resolves to 0
-      mockCollection.countDocuments.mockResolvedValue(0)
-      mockCollection.find.mockReturnValue(mockCursor)
-
-      const result = await bulkUpdateDeliveryStatus(mockSession, [mockFileId], FAILED, 'Test error message')
-
-      // this is the response from the db operation
-      const updatedEntry = mockCollection.updateMany.mock.calls[0]
-
-      expect(updatedEntry[0]).toEqual({ 'payload.file.fileId': { $in: [mockFileId] } })
-      // For failures we use an update pipeline: first stage sets lastAttemptedAt and error
-      const pipeline = updatedEntry[1]
-      expect(Array.isArray(pipeline)).toBe(true)
-      expect(pipeline[0]).toHaveProperty('$set')
-      expect(pipeline[0].$set).toMatchObject({ error: 'Test error message' })
-      expect(pipeline[1]).toHaveProperty('$set')
-      expect(pipeline[2]).toHaveProperty('$set')
-      // The final stage conditionally sets status to FAILED or PENDING
-      expect(JSON.stringify(pipeline[2])).toContain(FAILED)
-      expect(JSON.stringify(pipeline[2])).toContain(PENDING)
-
-      expect(result).toEqual(mockUpdateManyResult)
-    })
-
-    test('should throw error when database update fails', async () => {
-      const mockFileId = randomUUID()
-      mockCollection.updateMany.mockResolvedValue({ acknowledged: false })
-
-      await expect(bulkUpdateDeliveryStatus(mockSession, [mockFileId], SENT))
-        .rejects.toThrow('Failed to update outbox entries')
     })
   })
 })


### PR DESCRIPTION
Stacked on #153.

Adds atomic outbox message claiming, ownership-safe finalisation, unit tests, and real-MongoDB concurrency tests.