### PR TITLE
FLS1-114#4: add outbox concurrency QA tooling

### DIFF
--- a/compose.qa.yaml
+++ b/compose.qa.yaml
@@ -1,0 +1,10 @@
+services:
+  fcp-sfd-object-processor:
+    container_name: !reset null
+    ports: !reset []
+
+  mongodb:
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./scripts/qa:/qa:ro

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,0 +1,105 @@
+# Outbox concurrency QA test
+
+> **Non-production only.** Do not run this tooling against a production database.
+
+This test creates related metadata and `PENDING` outbox records so multiple object-processor instances can compete for work. It verifies atomic claim ownership; it does not provide exactly-once delivery. The outbox remains at-least-once and downstream consumers must remain idempotent.
+
+## Prerequisites
+
+- `mongosh` with authorised read/write access to the object processor database.
+- Permission to insert, query and delete records in `uploadMetadata` and `outbox`.
+- For local testing, Docker with Compose v2.
+- For an environment test, an approved non-production environment with at least two object-processor instances.
+
+Obtain database access through the team's approved method. Supply the connection string to `mongosh` when running the script. Do not add credentials, connection strings or environment-specific configuration to this repository.
+
+## Configuration
+
+The script reads these optional global configuration values. Set them with `mongosh --eval` before executing the script:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OUTBOX_QA_RECORD_COUNT` | `250` | Number of metadata and outbox records to create. Use more than twice `MONGO_OUTBOX_QUERY_LIMIT`. |
+| `OUTBOX_QA_TEST_RUN_ID` | Generated | Unique identifier attached to every generated record. Must be at least eight characters. |
+| `OUTBOX_QA_MODE` | `insert` | Set to `cleanup` to remove one test run. |
+| `OUTBOX_QA_CONFIRM_CLEANUP` | None | Must equal `DELETE <test-run-id>` before cleanup is allowed. |
+
+The generated file IDs and correlation IDs are unique and remain stable throughout retries. Reusing an existing test-run identifier is rejected.
+
+## Run locally with two instances
+
+The QA Compose overlay removes the fixed application container name and host ports, allowing Compose to create multiple workers. MongoDB remains available to the host on port `27017`.
+
+Start the stack from the repository root:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml up --build --scale fcp-sfd-object-processor=2
+```
+
+Confirm that two workers are running:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml ps fcp-sfd-object-processor
+```
+
+In another terminal, run the read-only mounted script using `mongosh` from the MongoDB container:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml exec -T mongodb mongosh "mongodb://localhost:27017/fcp-sfd-object-processor?replicaSet=rs0" /qa/outbox-concurrency.mongosh.js
+```
+
+This does not require `mongosh` to be installed on the host.
+
+To use an explicit test-run identifier or record count:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml exec -T mongodb mongosh "mongodb://localhost:27017/fcp-sfd-object-processor?replicaSet=rs0" --eval 'globalThis.OUTBOX_QA_TEST_RUN_ID="outbox-qa-local-001"; globalThis.OUTBOX_QA_RECORD_COUNT=250' /qa/outbox-concurrency.mongosh.js
+```
+
+Inspect both workers' structured logs:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml logs fcp-sfd-object-processor
+```
+
+## Run in a non-production environment
+
+1. Record the deployed version, CPU, memory and current instance count.
+2. Deploy the implementation and use **Edit** in the CDP Portal to set the object processor to at least two instances.
+3. Confirm from deployment information and logs that two distinct instances are running.
+4. Obtain an authorised `mongosh` connection using the team's approved method.
+5. Set `OUTBOX_QA_RECORD_COUNT` to more than twice the environment's `MONGO_OUTBOX_QUERY_LIMIT`; use at least `250` when the limit is `100`.
+6. Run `scripts/qa/outbox-concurrency.mongosh.js` against the `fcp-sfd-object-processor` database and record the printed test-run identifier.
+
+The script does not require CDP Terminal, MongoDB Compass or any other specific execution environment. CDP Terminal may be used only if it provides the required `mongosh` access and permissions.
+
+## Inspect the result
+
+The script prints inspection queries containing the exact test-run identifier. Run them in the same database. Also inspect structured application logs for that test period.
+
+Verify that:
+
+- at least two distinct worker identifiers claim records from the test run;
+- no record has overlapping valid claim ownership;
+- non-expired claims are not taken by another worker;
+- finalisation is performed only by the current claim owner;
+- successfully published records reach `SENT`;
+- no record remains indefinitely in `PROCESSING`.
+
+If practical, stop or redeploy one instance after it claims records. After the lease expires, verify that another worker reclaims them and that the previous owner cannot finalise them.
+
+Compose scheduling does not guarantee that both local workers receive records. The default volume makes participation likely, but the worker IDs in the logs are the evidence. Repeat with a larger record count if only one worker participates.
+
+Capture the instance count, worker identifiers, test-run identifier, relevant structured logs and final MongoDB status counts as evidence.
+
+## Clean up
+
+Cleanup is restricted to records carrying one explicit, non-empty test-run identifier. Copy the exact identifier printed during insertion and provide the required confirmation.
+
+Local container example:
+
+```sh
+docker compose -f compose.yaml -f compose.override.yaml -f compose.qa.yaml exec -T mongodb mongosh "mongodb://localhost:27017/fcp-sfd-object-processor?replicaSet=rs0" --eval 'globalThis.OUTBOX_QA_MODE="cleanup"; globalThis.OUTBOX_QA_TEST_RUN_ID="outbox-qa-local-001"; globalThis.OUTBOX_QA_CONFIRM_CLEANUP="DELETE outbox-qa-local-001"' /qa/outbox-concurrency.mongosh.js
+```
+
+The script reports the number of deleted `outbox` and `uploadMetadata` records. Query both collections using the test-run identifier and confirm that no matching records remain. Restore the original environment instance count after testing.

--- a/scripts/qa/outbox-concurrency.mongosh.js
+++ b/scripts/qa/outbox-concurrency.mongosh.js
@@ -1,0 +1,131 @@
+/* global db, ObjectId, print */
+
+// NON-PRODUCTION QA TOOLING ONLY.
+// Connection details must be supplied to mongosh; this script contains none.
+
+const readConfiguration = (name) => {
+  const value = globalThis[name]
+  return typeof value === 'string' ? value.trim() : value
+}
+const defaultRecordCount = 250
+const recordCount = Number.parseInt(readConfiguration('OUTBOX_QA_RECORD_COUNT') ?? `${defaultRecordCount}`, 10)
+const requestedTestRunId = readConfiguration('OUTBOX_QA_TEST_RUN_ID')
+const configuredMode = readConfiguration('OUTBOX_QA_MODE')
+const mode = typeof configuredMode === 'string' ? configuredMode.toLowerCase() : 'insert'
+
+const generateUuid = () => {
+  const first = new ObjectId().toString()
+  const second = new ObjectId().toString()
+
+  return `${first.slice(0, 8)}-${first.slice(8, 12)}-4${first.slice(13, 16)}-8${first.slice(17, 20)}-${first.slice(20, 24)}${second.slice(0, 8)}`
+}
+
+const generatedTestRunId = `outbox-qa-${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${new ObjectId()}`
+const testRunId = requestedTestRunId || generatedTestRunId
+
+const assertSafeTestRunId = () => {
+  if (!testRunId || testRunId.length < 8) {
+    throw new Error('OUTBOX_QA_TEST_RUN_ID must contain at least 8 characters')
+  }
+}
+
+const printInspectionQueries = () => {
+  print('Inspection queries:')
+  print(`db.outbox.aggregate([{ $match: { qaTestRunId: "${testRunId}" } }, { $group: { _id: "$status", count: { $sum: 1 } } }, { $sort: { _id: 1 } }])`)
+  print(`db.outbox.find({ qaTestRunId: "${testRunId}" }, { status: 1, attempts: 1, claimedBy: 1, claimedAt: 1, claimedUntil: 1, lastAttemptedAt: 1 }).sort({ createdAt: 1 })`)
+  print(`db.uploadMetadata.countDocuments({ qaTestRunId: "${testRunId}" })`)
+}
+
+const cleanUp = () => {
+  assertSafeTestRunId()
+
+  const expectedConfirmation = `DELETE ${testRunId}`
+  if (readConfiguration('OUTBOX_QA_CONFIRM_CLEANUP') !== expectedConfirmation) {
+    throw new Error(`Cleanup refused. Set OUTBOX_QA_CONFIRM_CLEANUP exactly to: ${expectedConfirmation}`)
+  }
+
+  const outboxResult = db.outbox.deleteMany({ qaTestRunId: testRunId })
+  const metadataResult = db.uploadMetadata.deleteMany({ qaTestRunId: testRunId })
+
+  print(`Cleaned QA test run: ${testRunId}`)
+  print(`Deleted outbox records: ${outboxResult.deletedCount}`)
+  print(`Deleted metadata records: ${metadataResult.deletedCount}`)
+}
+
+const buildMetadata = (index, fileId, correlationId) => {
+  const sequence = String(index + 1).padStart(6, '0')
+
+  return {
+    qaTestRunId: testRunId,
+    metadata: {
+      sbi: Number(`105${sequence}`),
+      crn: Number(`1050${sequence}`),
+      frn: Number(`1102${sequence}`),
+      submissionId: `${testRunId}-${sequence}`,
+      uosr: `${testRunId}-${sequence}`,
+      type: 'CS_Agreement_Evidence',
+      reference: `Outbox concurrency QA ${testRunId} record ${index + 1}`,
+      service: 'SFD-QA'
+    },
+    file: {
+      fileId,
+      filename: `outbox-concurrency-${testRunId}-${sequence}.pdf`,
+      contentType: 'application/pdf',
+      fileStatus: 'complete'
+    },
+    s3: {
+      key: `qa/${testRunId}/${fileId}.pdf`,
+      bucket: 'qa-placeholder-not-for-download'
+    },
+    messaging: {
+      publishedAt: null,
+      correlationId
+    },
+    raw: {
+      uploadStatus: 'complete',
+      numberOfRejectedFiles: 0
+    }
+  }
+}
+
+const insertTestData = () => {
+  assertSafeTestRunId()
+
+  if (!Number.isSafeInteger(recordCount) || recordCount < 1) {
+    throw new Error('OUTBOX_QA_RECORD_COUNT must be a positive integer')
+  }
+
+  if (db.outbox.countDocuments({ qaTestRunId: testRunId }) > 0 ||
+      db.uploadMetadata.countDocuments({ qaTestRunId: testRunId }) > 0) {
+    throw new Error(`Test-run identifier already exists: ${testRunId}`)
+  }
+
+  const metadataRecords = Array.from({ length: recordCount }, (_, index) => {
+    return buildMetadata(index, generateUuid(), generateUuid())
+  })
+  const metadataResult = db.uploadMetadata.insertMany(metadataRecords)
+  const insertedMetadataIds = Object.values(metadataResult.insertedIds)
+  const outboxRecords = insertedMetadataIds.map((messageId, index) => ({
+    qaTestRunId: testRunId,
+    messageId,
+    payload: metadataRecords[index],
+    status: 'PENDING',
+    attempts: 0,
+    createdAt: new Date()
+  }))
+  const outboxResult = db.outbox.insertMany(outboxRecords)
+
+  print('NON-PRODUCTION QA TOOLING')
+  print(`Test-run identifier: ${testRunId}`)
+  print(`Inserted metadata records: ${Object.keys(metadataResult.insertedIds).length}`)
+  print(`Inserted outbox records: ${Object.keys(outboxResult.insertedIds).length}`)
+  printInspectionQueries()
+}
+
+if (mode === 'cleanup') {
+  cleanUp()
+} else if (mode === 'insert') {
+  insertTestData()
+} else {
+  throw new Error('OUTBOX_QA_MODE must be either insert or cleanup')
+}

--- a/test/unit/repos/outbox.test.js
+++ b/test/unit/repos/outbox.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/no-multiple-empty-lines */
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 vi.mock('../../../src/config/index.js', () => {


### PR DESCRIPTION
# Description

Adds non-production QA tooling for validating outbox claim ownership across multiple object-processor instances.

The change includes a configurable mongosh data generator with test-run tagging and guarded cleanup, a Docker Compose overlay for running two local workers against shared MongoDB and SNS infrastructure, and documentation for local and CDP environment execution, inspection, evidence capture, and cleanup.

The local workflow was exercised with two object-processor instances: both workers claimed and finalized records, all 250 generated entries reached SENT, and cleanup removed exactly 250 outbox and 250 metadata records.

## Validation

- Linting passes
- Docker test suite passes
- Multi-instance Compose configuration validated
- Local two-instance concurrency workflow completed successfully

## Checklist

- [ ] has cloned repo locally
- [ ] has updated the ticket with version number
- [x] has successfully run service
- [x] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [x] have verified all tests pass
- [x] have checked README has been updated
- [ ] has verified code is maintable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity